### PR TITLE
feat: add support of `__str__` method in `LABEL_PATH_ENUM`

### DIFF
--- a/perception_dataset/constants.py
+++ b/perception_dataset/constants.py
@@ -130,6 +130,9 @@ class LABEL_PATH_ENUM(Enum):
         "config/label/traffic_light.yaml",
     )
 
+    def __str__(self) -> str:
+        return self.value
+
 
 def constant(f):
     def fset(self, value):

--- a/perception_dataset/utils/label_converter.py
+++ b/perception_dataset/utils/label_converter.py
@@ -9,9 +9,7 @@ from perception_dataset.constants import LABEL_PATH_ENUM
 class BaseConverter(ABC):
     def __init__(self, label_path: Union[str, LABEL_PATH_ENUM]) -> None:
         super().__init__()
-        if isinstance(label_path, LABEL_PATH_ENUM):
-            label_path = label_path.value
-        self.label_map: Dict[str, str] = self.__init_label_map(label_path)
+        self.label_map: Dict[str, str] = self.__init_label_map(str(label_path))
 
     @staticmethod
     def __init_label_map(label_path: str) -> Dict[str, str]:
@@ -34,10 +32,7 @@ class LabelConverter(BaseConverter):
         attribute_path: Union[str, LABEL_PATH_ENUM] = LABEL_PATH_ENUM.ATTRIBUTE,
     ) -> None:
         super().__init__(label_path)
-
-        if isinstance(attribute_path, LABEL_PATH_ENUM):
-            attribute_path = attribute_path.value
-        self.attribute_map: Dict[str, str] = self.__init_attribute_map(attribute_path)
+        self.attribute_map: Dict[str, str] = self.__init_attribute_map(str(attribute_path))
 
     @staticmethod
     def __init_attribute_map(attribute_path: str) -> Dict[str, str]:


### PR DESCRIPTION
## Description

<!-- Describe the changes -->

Add `__str__` method to `LABEL_PATH_ENUM` in order to cast it into string with `str()` not `isinstance()` in `LabelConverter()`

## How to review

<!-- Describe the review procedure -->

## How to test

### test data

<!-- Describe test data -->

### test command

<!-- Describe how to test this PR. -->

```bash

```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
