### PR TITLE
feat: support non key frame conversion

### DIFF
--- a/perception_dataset/deepen/deepen_to_t4_converter.py
+++ b/perception_dataset/deepen/deepen_to_t4_converter.py
@@ -254,6 +254,14 @@ class DeepenToT4Converter(AbstractConverter):
                 )
             if label_dict["sensor_id"][:6] == "camera" or label_dict["label_type"] == "box":
                 anno_two_d_bbox: List = label_dict["box"]
+
+                if anno_two_d_bbox[2] < 0 or anno_two_d_bbox[3] < 0:
+                    logger.error(f"bbox width or height:{anno_two_d_bbox} < 0")
+                    continue
+                if len(anno_two_d_bbox) != 4:
+                    logger.error(f"bbox length {len(anno_two_d_bbox)} != 4")
+                    continue
+
                 label_t4_dict.update(
                     {
                         "two_d_box": [

--- a/perception_dataset/t4_dataset/annotation_files_generator.py
+++ b/perception_dataset/t4_dataset/annotation_files_generator.py
@@ -259,7 +259,7 @@ class AnnotationFilesGenerator:
 
                 # Object Annotation
                 if "two_d_box" in anno.keys():
-                    anno_two_d_box: List[float] = anno["two_d_box"]
+                    anno_two_d_box: List[float] = self._clip_bbox(anno["two_d_box"], mask)
                     sensor_id: int = int(anno["sensor_id"])
                     if frame_index not in frame_index_to_sample_data_token[sensor_id]:
                         continue
@@ -271,6 +271,19 @@ class AnnotationFilesGenerator:
                         bbox=anno_two_d_box,
                         mask=mask[sensor_id][frame_index],
                     )
+
+    def _clip_bbox(self, bbox: List[float], mask: any) -> List[float]:
+        """Clip the bbox to the image size."""
+        try:
+            width, height = list(mask[0].values())[0]["size"]
+            bbox[0] = max(0, bbox[0])
+            bbox[1] = max(0, bbox[1])
+            bbox[2] = min(width, bbox[2])
+            bbox[3] = min(height, bbox[3])
+        except Exception as e:
+            print(e)
+
+        return bbox
 
     def _connect_annotations_in_scene(self):
         """Annotation for Instance and SampleAnnotation. This function adds the relationship between annotations."""

--- a/perception_dataset/utils/calculate_num_points.py
+++ b/perception_dataset/utils/calculate_num_points.py
@@ -17,6 +17,8 @@ def calculate_num_points(
     """Calcluate number of points in each box and overwrite the annotation table"""
     nusc = NuScenes(version="annotation", dataroot=dataroot, verbose=False)
     for sample in nusc.sample:
+        if not lidar_sensor_channel in sample["data"]:
+            continue
         lidar_token = sample["data"][lidar_sensor_channel]
         lidar_path, boxes, _ = nusc.get_sample_data(lidar_token)
 

--- a/perception_dataset/utils/calculate_num_points.py
+++ b/perception_dataset/utils/calculate_num_points.py
@@ -17,7 +17,7 @@ def calculate_num_points(
     """Calcluate number of points in each box and overwrite the annotation table"""
     nusc = NuScenes(version="annotation", dataroot=dataroot, verbose=False)
     for sample in nusc.sample:
-        if not lidar_sensor_channel in sample["data"]:
+        if lidar_sensor_channel not in sample["data"]:
             continue
         lidar_token = sample["data"][lidar_sensor_channel]
         lidar_path, boxes, _ = nusc.get_sample_data(lidar_token)


### PR DESCRIPTION
## Description
Support deepen to T4 format conversion for the data contains non-key-frame samples
<!-- Describe the changes -->

## How to review

<!-- Describe the review procedure -->

## How to test
Tested with T4 DBv1.1 dataset.

### test data
convert_deepen_to_t4.yaml:
```yaml
task: convert_deepen_to_t4
description:
  visibility:
    full: "No occlusion of the object."
    most: "Object is occluded, but by less than 50%."
    partial: "The object is occluded by more than 50% (but not completely)."
    none: "The object is 100% occluded and no points/pixels are visible in the label."
  camera_index:
    CAM_FRONT: 0
    CAM_FRONT_RIGHT: 1
    CAM_BACK_RIGHT: 2
    CAM_BACK: 3
    CAM_BACK_LEFT: 4
    CAM_FRONT_LEFT: 5

conversion:
  input_base: ./data/non_annotated_t4_format
  input_anno_file: ./data/deepen_format/lidar_annotations_accepted_deepen.json
  input_bag_base: ./data/rosbag2
  output_base: ./data/t4_format
  topic_list: ./config/topic_list_xx1_perception.yaml
  ignore_interpolate_label: True
  dataset_corresponding:
    V1.1_ODAIBA_1-1_0-100: fTIc0oV2V7VWT4UYZ98xSWKJ
```
<!-- Describe test data -->

### test command

<!-- Describe how to test this PR. -->

```bash
python -m awml_dataset.convert --config config/convert_deepen_to_t4.yaml
```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

