### PR TITLE
docs: update of setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ source /opt/ros/${ROS_DISTRO}/setup.sh
 sudo apt install -y ros-${ROS_DISTRO}-sensor-msgs-py ros-${ROS_DISTRO}-rosbag2-storage-mcap ros-${ROS_DISTRO}-radar-msgs
 
 mkdir src -p && vcs import src < build_depends.repos
-colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to autoware_auto_perception_msgs
+colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to tier4_perception_msgs
 source ./install/setup.bash
 ```
 


### PR DESCRIPTION
## Description

Update of setup instructions after changes in ROS dependencies in the repository.

## How to review and test
Not updated setup:
1. Setup the repository following the setup instructions from [README file in main branch](https://github.com/tier4/tier4_perception_dataset#setup).
2. [Run tests](https://github.com/tier4/tier4_perception_dataset#test)
3. You should have ```ModuleNotFoundError: No module named 'tier4_perception_msgs'```

Updated setup:
1. Setup the repository following the modified instructions from [README in this PR](https://github.com/tier4/tier4_perception_dataset/tree/docs/update-of-setup-instructions#setup) (in the new repository)
2. [Run tests](https://github.com/tier4/tier4_perception_dataset#test)
3. The tests should be passed

### test data
[Download test data](https://github.com/tier4/tier4_perception_dataset#download-test-data)

### test command

[Run tests](https://github.com/tier4/tier4_perception_dataset#test)

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
