### PR TITLE
fix(rosbag2_to_non_annotated_t4): frame number calc

### DIFF
--- a/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
@@ -170,11 +170,11 @@ class _Rosbag2ToNonAnnotatedT4Converter:
         num_frames_in_bag = min([self._bag_reader.get_topic_count(t) for t in topic_names])
         freq = 10
         num_frames_to_skip = int(self._skip_timestamp * freq)
-        max_num_frames = num_frames_in_bag - num_frames_to_skip
+        max_num_frames = num_frames_in_bag - num_frames_to_skip - 1
         num_frames_to_crop = 0
 
         if not (self._num_load_frames > 0 and self._num_load_frames <= max_num_frames):
-            self._num_load_frames = max_num_frames - 1
+            self._num_load_frames = max_num_frames
             logger.info(
                 f"max. possible number of frames will be loaded based on topic count"
                 f" since the value in config is not in (0, num_frames_in_bag - num_frames_to_skip = {max_num_frames}> range."

--- a/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
@@ -174,7 +174,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
         num_frames_to_crop = 0
 
         if not (self._num_load_frames > 0 and self._num_load_frames <= max_num_frames):
-            self._num_load_frames = max_num_frames
+            self._num_load_frames = (max_num_frames - 1)
             logger.info(
                 f"max. possible number of frames will be loaded based on topic count"
                 f" since the value in config is not in (0, num_frames_in_bag - num_frames_to_skip = {max_num_frames}> range."

--- a/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
@@ -174,7 +174,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
         num_frames_to_crop = 0
 
         if not (self._num_load_frames > 0 and self._num_load_frames <= max_num_frames):
-            self._num_load_frames = (max_num_frames - 1)
+            self._num_load_frames = max_num_frames - 1
             logger.info(
                 f"max. possible number of frames will be loaded based on topic count"
                 f" since the value in config is not in (0, num_frames_in_bag - num_frames_to_skip = {max_num_frames}> range."

--- a/tests/test_t4_dataset_conversion.py
+++ b/tests/test_t4_dataset_conversion.py
@@ -304,7 +304,9 @@ def test_sample_annotation_json(t4_dataset_path):
 @pytest.mark.parametrize("t4_dataset_path", [False], indirect=True)
 def test_sample_annotation_json_with_interpolate_label(t4_dataset_path):
     sample_annotation = load_json(t4_dataset_path, "sample_annotation")
-    assert len(sample_annotation) == 54, f"sample_annotation length is {len(sample_annotation)}, expected 54"
+    assert (
+        len(sample_annotation) == 54
+    ), f"sample_annotation length is {len(sample_annotation)}, expected 54"
     for sample_anno in sample_annotation:
         sample_anno: dict
         assert sample_anno["token"], "token is empty"

--- a/tests/test_t4_dataset_conversion.py
+++ b/tests/test_t4_dataset_conversion.py
@@ -219,7 +219,7 @@ def test_category_json(t4_dataset_path, category_list):
 @pytest.mark.parametrize("t4_dataset_path", [True], indirect=True)
 def test_ego_pose_json(t4_dataset_path):
     ego_pose_json = load_json(t4_dataset_path, "ego_pose")
-    assert len(ego_pose_json) == 197, f"ego_pose length is {len(ego_pose_json)}, expected 197"
+    assert len(ego_pose_json) == 190, f"ego_pose length is {len(ego_pose_json)}, expected 190"
     for ego_pose in ego_pose_json:
         assert ego_pose["translation"], "translation is empty"
         assert ego_pose["rotation"], "rotation is empty"
@@ -282,8 +282,8 @@ def test_object_ann_json(t4_dataset_path):
 def test_sample_annotation_json(t4_dataset_path):
     sample_annotation = load_json(t4_dataset_path, "sample_annotation")
     assert (
-        len(sample_annotation) == 30
-    ), f"sample_annotation length is {len(sample_annotation)}, expected 30"
+        len(sample_annotation) == 29
+    ), f"sample_annotation length is {len(sample_annotation)}, expected 29"
     for sample_anno in sample_annotation:
         sample_anno: dict
         assert sample_anno["token"], "token is empty"
@@ -304,7 +304,7 @@ def test_sample_annotation_json(t4_dataset_path):
 @pytest.mark.parametrize("t4_dataset_path", [False], indirect=True)
 def test_sample_annotation_json_with_interpolate_label(t4_dataset_path):
     sample_annotation = load_json(t4_dataset_path, "sample_annotation")
-    assert len(sample_annotation) == 56
+    assert len(sample_annotation) == 54, f"sample_annotation length is {len(sample_annotation)}, expected 54"
     for sample_anno in sample_annotation:
         sample_anno: dict
         assert sample_anno["token"], "token is empty"
@@ -326,8 +326,8 @@ def test_sample_annotation_json_with_interpolate_label(t4_dataset_path):
 def test_sample_data_json(t4_dataset_path):
     sample_data_json = load_json(t4_dataset_path, "sample_data")
     assert (
-        len(sample_data_json) == 196
-    ), f"sample_data length is {len(sample_data_json)}, expected 196"
+        len(sample_data_json) == 189
+    ), f"sample_data length is {len(sample_data_json)}, expected 189"
     for sample_data in sample_data_json:
         assert sample_data["token"], "token is empty"
         assert sample_data["sample_token"], "sample_token is empty"
@@ -346,7 +346,7 @@ def test_sample_data_json(t4_dataset_path):
 @pytest.mark.parametrize("t4_dataset_path", [True], indirect=True)
 def test_sample_json(t4_dataset_path):
     sample_json = load_json(t4_dataset_path, "sample")
-    assert len(sample_json) == 28, f"sample length is {len(sample_json)}, expected 28"
+    assert len(sample_json) == 27, f"sample length is {len(sample_json)}, expected 27"
     for sample in sample_json:
         assert sample["token"], "token is empty"
         assert sample["timestamp"], "timestamp is empty"


### PR DESCRIPTION
## Description
Correct a bug in calculating the generatable frame number
<!-- Describe the changes -->

## How to review

<!-- Describe the review procedure -->

## How to test
Verify that the conversion is successfully completed without any issues using a rosbag in which some topics are dropped.
### test data

<!-- Describe test data -->

### test command

<!-- Describe how to test this PR. -->

```bash
python -m perception_dataset.convert --config config/convert_rosbag2_to_non_annotated_t4_sample.yaml --overwrite 

```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
