### PR TITLE
feat: add data interpolation

### DIFF
--- a/config/interpolate_t4.yaml
+++ b/config/interpolate_t4.yaml
@@ -1,0 +1,8 @@
+task: interpolate
+description:
+  scene: ""
+conversion:
+  input_base: ./data/t4_dataset
+  output_base: ./data/interpolate
+  target_hz: 10.0
+  method: cubic

--- a/config/interpolate_t4.yaml
+++ b/config/interpolate_t4.yaml
@@ -4,4 +4,3 @@ description:
 conversion:
   input_base: ./data/t4_dataset
   output_base: ./data/interpolate
-  target_hz: 10.0

--- a/config/interpolate_t4.yaml
+++ b/config/interpolate_t4.yaml
@@ -1,8 +1,7 @@
 task: interpolate
 description:
-  scene: ""
+  scene: "Interpolate"
 conversion:
   input_base: ./data/t4_dataset
   output_base: ./data/interpolate
   target_hz: 10.0
-  method: cubic

--- a/docs/tasks/interpolate.md
+++ b/docs/tasks/interpolate.md
@@ -5,7 +5,7 @@ Interpolate 3D annotations based on LiDAR timestamps recorded in sample data.
 ## Assumptions
 
 - LiDAR and 3D annotation data is included.
-- Sample and sample annotation records will be interpolated with non-key frame timestamp that corresponding LiDAR timestamp has.
+- Sample and sample annotation records will be interpolated with the non-key frame timestamp corresponding to the LiDAR timestamp.
 
 ## Metadata updates
 
@@ -31,7 +31,7 @@ By interpolation, the following metadata will be updated.
 - **sample_data.json**
   - Set the updated `sample_token` with the interpolated `sample` and set `is_key_frame=True`
     - `token` ..._No update_
-    - `sample_token` ...If `is_key_frame=False` and LiDAR data, add new sample and set its token
+    - `sample_token` ...If `is_key_frame=False` and LiDAR data is, add a new sample and set its token
     - `ego_pose_token` ..._No update_
     - `calibrated_sensor_token` ..._No update_
     - `filename` ..._No update_
@@ -39,34 +39,34 @@ By interpolation, the following metadata will be updated.
     - `width` ..._No update_
     - `height` ..._No update_
     - `timestamp` ..._No update_
-    - `is_key_frame` ...Set `True` if there is corresponding an interpolated `sample`
+    - `is_key_frame` ...Set `True` if there is a corresponding interpolated `sample`
     - `next` ..._No update_
     - `prev` ..._No update_
 - **sample.json**
-  - Add new record with the interpolated `timestamp`.
+  - Add a new record with the interpolated `timestamp`.
   - Update `next/prev` token in the original record if there are any new records around at its `timestamp`.
     - `token` ..._No update_
     - `timestamp` ..._No update_
     - `scene_token` ..._No update_
-    - `next` ...Update if there is new next record
-    - `prev` ...Update if there is new previous record
+    - `next` ...Update if there is a new next record
+    - `prev` ...Update if there is a new previous record
 - **sample_annotation.json**
-  - Add new record interpolating `translation/rotation/velocity/acceleration` with the corresponding timestamp
+  - Add a new record interpolating `translation/rotation/velocity/acceleration` with the corresponding timestamp
   - Update `next/prev` token in the original record if there are any new records around at its `timestamp`.
     - `token` ..._No update_
     - `sample_token` ...Fill with the corresponding token of `sample`
     - `instance_token` ..._No update_
     - `attribute_tokens` ..._No update_
-    - `visibility_token` ...Set same value with the latest previous original `sample_annotation` for same instance
+    - `visibility_token` ...Set the same value with the latest previous original `sample_annotation` for the same instance
     - `translation` ...Interpolate with `CUBIC_SPLINE`
     - `velocity` ...Interpolate with `CUBIC_SPLINE` if not `None`
     - `acceleration` ...Interpolate with `CUBIC_SPLINE` if not `None`
-    - `size` ...Set same value with the latest previous original `sample_annotation` for same instance
+    - `size` ...Set the same value with the latest previous original `sample_annotation` for the same instance
     - `rotation` ...Interpolate with `SLERP`
-    - `num_lidar_pts` ...Set same value with the latest previous original `sample_annotation` for same instance
-    - `num_radar_pts` ...Set same value with the latest previous original `sample_annotation` for same instance
-    - `next` ...Update if there is new next record
-    - `prev` ...Update if there is new previous record
+    - `num_lidar_pts` ...Set the same value with the latest previous original `sample_annotation` for the same instance
+    - `num_radar_pts` ...Set the same value with the latest previous original `sample_annotation` for the same instance
+    - `next` ...Update if there is a new next record
+    - `prev` ...Update if there is a new previous record
 
 ## Quick Start
 
@@ -83,7 +83,6 @@ description:
 conversion:
   input_base: ./data/t4_dataset     ...Input base directory path
   output_base: ./data/interpolate   ...Output base directory path
-  target_hz: 10.0                   ...Target Hz
 ```
 
 ## Check Interpolation Result

--- a/docs/tasks/interpolate.md
+++ b/docs/tasks/interpolate.md
@@ -1,0 +1,72 @@
+# Data Interpolation
+
+Interpolate annotations with specified Hz.
+
+By interpolation, the following metadata will be interpolated.
+
+- **scene.json**
+  - Only update `description` and `nbr_samples`
+    - `token` ..._No update_
+    - `name` ..._No update_
+    - `description` ...Insert `interpolate`
+    - `log_token` ..._No update_
+    - `nbr_samples` ...Update with the number of interpolated `sample`
+    - `first_sample_token` ..._No update_
+    - `last_sample_token` ..._No update_
+- **instance.json**
+  - Only update `nbr_annotations`
+    - `token` ..._No update_
+    - `category_token` ..._No update_
+    - `instance_name` ..._No update_
+    - `nbr_annotations` ...Update with the number of interpolated `sample_annotation`
+    - `first_annotation_token` ..._No update_
+    - `last_annotation_token` ..._No update_
+- **sample.json**
+  - Add new record with the interpolated `timestamp`.
+  - Update `next/prev` token in the original record if there are any new records around at its `timestamp`.
+    - `token` ..._No update_
+    - `timestamp` ..._No update_
+    - `scene_token` ..._No update_
+    - `next` ...Update if there is new next record
+    - `prev` ...Update if there is new previous record
+- **sample_annotation.json**
+  - Add new record interpolating `translation/rotation/velocity/acceleration` with the corresponding timestamp
+  - Update `next/prev` token in the original record if there are any new records around at its `timestamp`.
+    - `token` ..._No update_
+    - `sample_token` ...Fill with the corresponding token of `sample`
+    - `instance_token` ..._No update_
+    - `attribute_tokens` ..._No update_
+    - `visibility_token` ...Set same value with the latest previous original `sample_annotation` for same instance
+    - `translation` ...Interpolate with `CUBIC_SPLINE`
+    - `velocity` ...Interpolate with `CUBIC_SPLINE` if not `None`
+    - `acceleration` ...Interpolate with `CUBIC_SPLINE` if not `None`
+    - `size` ...Set same value with the latest previous original `sample_annotation` for same instance
+    - `rotation` ...Interpolate with `SLERP`
+    - `num_lidar_pts` ...Set same value with the latest previous original `sample_annotation` for same instance
+    - `num_radar_pts` ...Set same value with the latest previous original `sample_annotation` for same instance
+    - `next` ...Update if there is new next record
+    - `prev` ...Update if there is new previous record
+
+## Quick Start
+
+```bash
+python3 -m perception_dataset.convert --config <INTERPOLATION_CONFIG>
+```
+
+### Config Settings
+
+```yaml
+task: interpolate                   ...Task name
+description:
+  scene: "Interpolate"              ...Scene description
+conversion:
+  input_base: ./data/t4_dataset     ...Input base directory path
+  output_base: ./data/interpolate   ...Output base directory path
+  target_hz: 10.0                   ...Target Hz
+```
+
+## Check Interpolation Result
+
+```bash
+python3 perception_dataset/t4_dataset/data_interpolator.py <INTERPOLATED_DATA_BASE>
+```

--- a/docs/tasks/interpolate.md
+++ b/docs/tasks/interpolate.md
@@ -1,8 +1,15 @@
 # Data Interpolation
 
-Interpolate annotations with specified Hz.
+Interpolate 3D annotations based on LiDAR timestamps recorded in sample data.
 
-By interpolation, the following metadata will be interpolated.
+## Assumptions
+
+- LiDAR and 3D annotation data is included.
+- Sample and sample annotation records will be interpolated with non-key frame timestamp that corresponding LiDAR timestamp has.
+
+## Metadata updates
+
+By interpolation, the following metadata will be updated.
 
 - **scene.json**
   - Only update `description` and `nbr_samples`
@@ -21,6 +28,20 @@ By interpolation, the following metadata will be interpolated.
     - `nbr_annotations` ...Update with the number of interpolated `sample_annotation`
     - `first_annotation_token` ..._No update_
     - `last_annotation_token` ..._No update_
+- **sample_data.json**
+  - Set the updated `sample_token` with the interpolated `sample` and set `is_key_frame=True`
+    - `token` ..._No update_
+    - `sample_token` ...If `is_key_frame=False` and LiDAR data, add new sample and set its token
+    - `ego_pose_token` ..._No update_
+    - `calibrated_sensor_token` ..._No update_
+    - `filename` ..._No update_
+    - `fileformat` ..._No update_
+    - `width` ..._No update_
+    - `height` ..._No update_
+    - `timestamp` ..._No update_
+    - `is_key_frame` ...Set `True` if there is corresponding an interpolated `sample`
+    - `next` ..._No update_
+    - `prev` ..._No update_
 - **sample.json**
   - Add new record with the interpolated `timestamp`.
   - Update `next/prev` token in the original record if there are any new records around at its `timestamp`.

--- a/perception_dataset/convert.py
+++ b/perception_dataset/convert.py
@@ -296,6 +296,30 @@ def main():
         converter.convert()
         logger.info(f"[Done] Merging T4 dataset ({input_base}) into T4 dataset ({output_base})")
 
+    elif task == "interpolate":
+        from perception_dataset.t4_dataset.data_interpolator import DataInterpolator
+
+        input_base = config_dict["conversion"]["input_base"]
+        output_base = config_dict["conversion"]["output_base"]
+        target_hz = config_dict["conversion"].get("target_hz", 10.0)
+        method = config_dict["conversion"].get("method", "cubic")
+
+        converter = DataInterpolator(
+            input_base=input_base,
+            output_base=output_base,
+            target_hz=target_hz,
+            method=method,
+            logger=logger,
+        )
+
+        logger.info(
+            f"[BEGIN] Interpolating {input_base} into {output_base} as {target_hz} Hz with {method}"
+        )
+        converter.convert()
+        logger.info(
+            f"[DONE] Interpolating {input_base} into {output_base} as {target_hz} Hz with {method}"
+        )
+
     else:
         raise NotImplementedError()
 

--- a/perception_dataset/convert.py
+++ b/perception_dataset/convert.py
@@ -302,23 +302,17 @@ def main():
         input_base = config_dict["conversion"]["input_base"]
         output_base = config_dict["conversion"]["output_base"]
         target_hz = config_dict["conversion"].get("target_hz", 10.0)
-        method = config_dict["conversion"].get("method", "cubic")
 
         converter = DataInterpolator(
             input_base=input_base,
             output_base=output_base,
             target_hz=target_hz,
-            method=method,
             logger=logger,
         )
 
-        logger.info(
-            f"[BEGIN] Interpolating {input_base} into {output_base} as {target_hz} Hz with {method}"
-        )
+        logger.info(f"[BEGIN] Interpolating {input_base} into {output_base} as {target_hz} Hz")
         converter.convert()
-        logger.info(
-            f"[DONE] Interpolating {input_base} into {output_base} as {target_hz} Hz with {method}"
-        )
+        logger.info(f"[DONE] Interpolating {input_base} into {output_base} as {target_hz} Hz")
 
     else:
         raise NotImplementedError()

--- a/perception_dataset/convert.py
+++ b/perception_dataset/convert.py
@@ -301,18 +301,16 @@ def main():
 
         input_base = config_dict["conversion"]["input_base"]
         output_base = config_dict["conversion"]["output_base"]
-        target_hz = config_dict["conversion"].get("target_hz", 10.0)
 
         converter = DataInterpolator(
             input_base=input_base,
             output_base=output_base,
-            target_hz=target_hz,
             logger=logger,
         )
 
-        logger.info(f"[BEGIN] Interpolating {input_base} into {output_base} as {target_hz} Hz")
+        logger.info(f"[BEGIN] Interpolating {input_base} into {output_base}")
         converter.convert()
-        logger.info(f"[DONE] Interpolating {input_base} into {output_base} as {target_hz} Hz")
+        logger.info(f"[DONE] Interpolating {input_base} into {output_base}")
 
     else:
         raise NotImplementedError()

--- a/perception_dataset/t4_dataset/data_interpolator.py
+++ b/perception_dataset/t4_dataset/data_interpolator.py
@@ -313,7 +313,10 @@ class DataInterpolator(AbstractConverter):
                     all_original_sample_timestamps[ann["sample_token"]] * 1e-3
                 )
 
-            sample_anns.sort(key=lambda s: all_original_sample_timestamps[s["timestamp"]])
+            if len(original_timestamps_msec) < 2:
+                continue
+
+            sample_anns.sort(key=lambda s: all_original_sample_timestamps[s["sample_token"]])
 
             original_timestamps_msec = np.array(sorted(original_timestamps_msec))
             translations = np.array(

--- a/perception_dataset/t4_dataset/data_interpolator.py
+++ b/perception_dataset/t4_dataset/data_interpolator.py
@@ -1,0 +1,494 @@
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import Callable, Union, List, Dict, Any, Optional
+from glob import glob
+import os.path as osp
+import os
+import json
+
+from secrets import token_hex
+from nuscenes import NuScenes
+from scipy import interpolate
+from perception_dataset.abstract_converter import AbstractConverter
+from perception_dataset.utils.logger import configure_logger
+import numpy as np
+from scipy.spatial.transform import Rotation, Slerp
+
+
+class InterpolationMethod(Enum):
+    CUBIC = "CUBIC"
+    QUADRATIC = "QUADRATIC"
+    NEAREST = "NEAREST"
+    LINEAR = "LINEAR"
+    LAGRANGE = "LAGRANGE"
+    AKIMA = "AKIMA"
+
+    @classmethod
+    def from_str(cls, name: str) -> InterpolationMethod:
+        name = name.upper()
+        assert name in cls.__members__, f"{name} is not in enum members"
+        return cls.__members__[name]
+
+    def __eq__(self, __value: Union[str, InterpolationMethod]) -> bool:
+        if isinstance(__value, str):
+            return self.value == __value.upper()
+        else:
+            return super().__eq__(__value)
+
+    def get_func(self) -> Callable:
+        if self == "cubic":
+            return lambda x, y: interpolate.interp1d(x, y, kind="cubic")
+        elif self == "quadratic":
+            return lambda x, y: interpolate.interp1d(x, y, kind="quadratic")
+        elif self == "nearest":
+            return lambda x, y: interpolate.interp1d(x, y, kind="nearest")
+        elif self == "linear":
+            return lambda x, y: interpolate.interp1d(x, y, kind="linear")
+        elif self == "lagrange":
+            return interpolate.lagrange
+        elif self == "akima":
+            return interpolate.Akima1DInterpolator
+
+
+class DataInterpolator(AbstractConverter):
+    """A class to interpolate annotations."""
+
+    EGO_POSE_KEYS = ("token", "translation", "rotation", "timestamp")
+    SAMPLE_KEYS = ("token", "timestamp", "scene_token", "next", "prev")
+    SAMPLE_DATA_KEYS = (
+        "token",
+        "sample_token",
+        "ego_pose_token",
+        "calibrated_sensor_token",
+        "filename",
+        "fileformat",
+        "width",
+        "height",
+        "timestamp",
+        "is_key_frame",
+        "next",
+        "prev",
+        "is_valid",
+    )
+    SAMPLE_ANN_KEYS = (
+        "token",
+        "sample_token",
+        "instance_token",
+        "attribute_tokens",
+        "visibility_token",
+        "translation",
+        "velocity",
+        "acceleration",
+        "size",
+        "rotation",
+        "num_lidar_pts",
+        "num_radar_pts",
+        "next",
+        "prev",
+    )
+
+    def __init__(
+        self,
+        input_base: str,
+        output_base: str,
+        target_hz: float = 10.0,
+        method: Union[str, InterpolationMethod] = "cubic",
+        logger: Optional[logging.RootLogger] = None,
+    ) -> None:
+        super().__init__(input_base, output_base)
+        self._dataset_paths = glob(osp.join(input_base, "*"))
+        self._method = InterpolationMethod.from_str(method) if isinstance(method, str) else method
+        self._interpolation = self._method.get_func()
+        self._target_hz = target_hz
+        self._interpolate_step = 100.0 / self._target_hz  # [msec]
+        self.logger = configure_logger(modname=__name__) if logger is None else logger
+
+    def convert(self) -> None:
+        """Interpolate the following annotation files.
+        * `sample.json`
+        * `sample_data.json`
+        * `sample_annotation.json`
+        * `ego_pose.json`
+        """
+        for data_root in self._dataset_paths:
+            dataset_id = osp.basename(data_root)
+            output_path = osp.join(self._output_base, dataset_id)
+            os.makedirs(output_path, exist_ok=True)
+            os.system(f"cp -r {data_root} {self._output_base}")
+
+            nusc = NuScenes(version="annotation", dataroot=data_root, verbose=False)
+
+            all_ego_poses = self.get_interpolated_ego_poses(nusc)
+            self.logger.info("Finish interpolating ego pose")
+
+            all_samples = self.get_interpolated_samples(nusc)
+            self.logger.info("Finish interpolating sample")
+
+            all_sample_data = self.get_interpolated_sample_data(nusc, all_ego_poses, all_samples)
+            self.logger.info("Finish interpolating sample data")
+
+            all_sample_annotations = self.get_interpolated_sample_annotations(nusc, all_samples)
+            self.logger.info("Finish interpolating sample annotation")
+
+            # save
+            annotation_root = osp.join(output_path, nusc.version)
+            self._save_json(all_ego_poses, osp.join(annotation_root, "ego_pose.json"))
+            self._save_json(all_samples, osp.join(annotation_root, "sample.json"))
+            self._save_json(all_sample_data, osp.join(annotation_root, "sample_data.json"))
+            self._save_json(
+                all_sample_annotations, osp.join(annotation_root, "sample_annotation.json")
+            )
+
+    def get_interpolated_ego_poses(self, nusc: NuScenes) -> List[Dict[str, Any]]:
+        """
+        Extend ego pose records with interpolation.
+
+        The keys of ego pose are as follows.
+        * token (str)
+        * translation (list[float])
+        * rotation (list[float])
+        * timestamp (int)
+
+        Args:
+            nusc (NuScenes)
+
+        Returns:
+            List[Dict[str, Any]]
+        """
+        timestamps_msec = []
+        translations = []
+        rotations = []
+        all_ego_poses: List[Dict[str, Any]] = sorted(nusc.ego_pose, key=lambda e: e["timestamp"])
+        for ego_pose in all_ego_poses:
+            timestamps_msec.append(ego_pose["timestamp"] * 1e-3)
+            translations.append(ego_pose["translation"])
+            rotations.append(ego_pose["rotation"])
+        translations = np.array([t for _, t in sorted(zip(timestamps_msec, translations))])
+        rotations = np.array([r for _, r in sorted(zip(timestamps_msec, rotations))])
+
+        timestamps_msec, unique_idx = np.unique(timestamps_msec, return_index=True)
+        translations = translations[unique_idx]
+        rotations = rotations[unique_idx]
+        rotations = Rotation.from_quat(rotations)
+
+        func_x = self._interpolation(timestamps_msec, translations[:, 0])
+        func_y = self._interpolation(timestamps_msec, translations[:, 1])
+        func_z = self._interpolation(timestamps_msec, translations[:, 2])
+        slerp = Slerp(timestamps_msec, rotations)
+
+        num_times = len(timestamps_msec)
+        inter_times = np.concatenate(
+            [
+                np.arange(
+                    timestamps_msec[i] + self._interpolate_step,
+                    timestamps_msec[i + 1],
+                    self._interpolate_step,
+                )
+                for i in range(num_times - 1)
+            ]
+        )
+        inter_tx = func_x(inter_times)
+        inter_ty = func_y(inter_times)
+        inter_tz = func_z(inter_times)
+        inter_quat = slerp(inter_times).as_quat()
+
+        for time, tx, ty, tz, quat in zip(inter_times, inter_tx, inter_ty, inter_tz, inter_quat):
+            inter_ego_info = {
+                "token": token_hex(16),
+                "translation": [tx, ty, tz],
+                "rotation": quat.tolist(),
+                "timestamp": int(time * 1e3),
+            }
+            all_ego_poses.append(inter_ego_info)
+
+        all_ego_poses = sorted(all_ego_poses, key=lambda e: e["timestamp"])
+
+        return all_ego_poses
+
+    def get_interpolated_samples(self, nusc: NuScenes) -> List[Dict[str, Any]]:
+        """
+        Extend sample records with interpolation.
+
+        The keys of sample are as follows.
+        * token (str)
+        * timestamp (int)
+        * scene_token (str)
+        * next (str)
+        * prev (str)
+
+        Args:
+            nusc (NuScenes): _description_
+
+        Returns:
+            List[Dict[str, Any]]: _description_
+        """
+        original_samples: List[Dict[str, Any]] = sorted(
+            [{name: record[name] for name in self.SAMPLE_KEYS} for record in nusc.sample],
+            key=lambda s: s["timestamp"],
+        )
+        all_samples = original_samples.copy()
+        for sample in original_samples:
+            next_token = sample["next"]
+            if next_token == "":
+                continue
+            next_sample = nusc.get("sample", next_token)
+            curr_msec = sample["timestamp"] * 1e-3
+            next_msec = next_sample["timestamp"] * 1e-3
+            msec_list = np.arange(
+                curr_msec + self._interpolate_step,
+                next_msec,
+                self._interpolate_step,
+            )
+
+            inter_token = token_hex(16)
+            inter_prev_token: str = sample["token"]
+            for i, msec in enumerate(msec_list):
+                inter_next_token = token_hex(16) if i != len(msec_list) - 1 else next_token
+                all_samples.append(
+                    {
+                        "token": inter_token,
+                        "timestamp": int(msec * 1e3),
+                        "scene_token": sample["scene_token"],
+                        "next": inter_next_token,
+                        "prev": inter_prev_token,
+                    }
+                )
+                inter_prev_token = inter_token
+                inter_token = inter_next_token
+            all_samples = sorted(all_samples, key=lambda s: s["timestamp"])
+        return all_samples
+
+    def get_interpolated_sample_data(
+        self,
+        nusc: NuScenes,
+        interpolated_ego_poses: List[Dict[str, Any]],
+        interpolated_samples: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """
+        Extend sample data records with interpolation.
+
+        The keys of sample data are as follows.
+        * token (str)
+        * sample_token (str)
+        * ego_pose_token (str)
+        * calibrated_sensor_token (str)
+        * filename (str)
+        * fileformat (str)
+        * width (int)
+        * height (int)
+        * timestamp (int)
+        * is_key_frame (bool)
+        * next (str)
+        * prev (str)
+        * is_valid (bool)
+        """
+        all_sample_data = sorted(
+            [{key: s.get(key) for key in self.SAMPLE_DATA_KEYS} for s in nusc.sample_data],
+            key=lambda s: s["timestamp"],
+        )
+
+        for sample_data in all_sample_data:
+            next_token: str = sample_data["next"]
+            if next_token == "":
+                continue
+            next_sample_data = nusc.get("sample_data", next_token)
+            curr_msec = sample_data["timestamp"] * 1e-3
+            next_msec = next_sample_data["timestamp"] * 1e-3
+            msec_list = np.arange(
+                curr_msec + self._interpolate_step,
+                next_msec,
+                self._interpolate_step,
+            )
+
+            inter_token = token_hex(16)
+            inter_prev_token: str = sample_data["token"]
+            for i, msec in enumerate(msec_list):
+                inter_next_token = token_hex(16) if i != len(msec_list) - 1 else next_token
+                inter_sample_token = self._get_closest_timestamp(
+                    interpolated_samples, int(msec * 1e3)
+                )["token"]
+                inter_ego_token = self._get_closest_timestamp(
+                    interpolated_ego_poses, int(msec * 1e3)
+                )["token"]
+                all_sample_data.append(
+                    {
+                        "token": inter_token,
+                        "sample_token": inter_sample_token,
+                        "ego_pose_token": inter_ego_token,
+                        "calibrated_sensor_token": sample_data["calibrated_sensor_token"],
+                        "filename": "",
+                        "fileformat": sample_data["fileformat"],
+                        "width": sample_data["width"],
+                        "height": sample_data["height"],
+                        "timestamp": int(msec * 1e3),
+                        "is_key_frame": True,
+                        "next": inter_next_token,
+                        "prev": inter_prev_token,
+                        "is_valid": False,
+                    }
+                )
+                inter_prev_token = inter_token
+                inter_token = inter_next_token
+
+            all_sample_data = sorted(all_sample_data, key=lambda s: s["timestamp"])
+            return all_sample_data
+
+    def get_interpolated_sample_annotations(
+        self,
+        nusc: NuScenes,
+        interpolated_samples: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """
+        Extend sample annotation records with interpolation.
+
+        The keys of sample annotation are as follows.
+        * token (str)
+        * sample_token (str)
+        * instance_token (str)
+        * attribute_tokens (list[str])
+        * visibility_token (str)
+        * translation (list[float])
+        * velocity (list[float])
+        * acceleration (list[float])
+        * size (list[float])
+        * rotation (list[float])
+        * num_lidar_pts (int)
+        * num_radar_pts (int)
+        * next (str)
+        * prev (str)
+        """
+        all_sample_annotations = [
+            {key: s.get(key) for key in self.SAMPLE_ANN_KEYS} for s in nusc.sample_annotation
+        ]
+
+        original_sample_timestamps = {s["token"]: s["timestamp"] for s in nusc.sample}
+        interpolated_sample_timestamps: List[Dict[str, int]] = []
+        for sample in interpolated_samples:
+            is_interpolated = sample["timestamp"] not in original_sample_timestamps.values()
+            if is_interpolated:
+                interpolated_sample_timestamps.append({sample["token"]: sample["timestamp"]})
+
+        all_instance_anns = {ins["token"]: [] for ins in nusc.instance}
+        for ann in all_sample_annotations:
+            all_instance_anns[ann["instance_token"]].append(ann)
+
+        for ins_token, sample_anns in all_instance_anns.items():
+            translations = []
+            rotations = []
+            velocities = []
+            accelerations = []
+            original_timestamps_msec = []
+            for ann in sample_anns:
+                translations.append(ann["translation"])
+                rotations.append(ann["rotation"])
+                velocities.append(ann["velocity"])
+                accelerations.append(ann["acceleration"])
+                original_timestamps_msec.append(
+                    original_sample_timestamps[ann["sample_token"]] * 1e-3
+                )
+
+            original_timestamps_msec = np.array(sorted(original_timestamps_msec))
+            translations = np.array(
+                [t for _, t in sorted(zip(original_timestamps_msec, translations))]
+            )
+            func_x = self._interpolation(original_timestamps_msec, translations[:, 0])
+            func_y = self._interpolation(original_timestamps_msec, translations[:, 1])
+            func_z = self._interpolation(original_timestamps_msec, translations[:, 2])
+
+            rotations = Rotation.from_quat(
+                np.array([r for _, r in sorted(zip(original_timestamps_msec, rotations))])
+            )
+            slerp = Slerp(original_timestamps_msec, rotations)
+
+            if all(velocities):
+                velocities = [v for _, v in sorted(zip(original_timestamps_msec, velocities))]
+                func_vel = self._interpolation(original_timestamps_msec, velocities)
+            else:
+                func_vel = None
+
+            if all(accelerations):
+                accelerations = [
+                    a for _, a in sorted(zip(original_timestamps_msec, accelerations))
+                ]
+                func_acc = self._interpolation(original_timestamps_msec, accelerations)
+            else:
+                func_acc = None
+
+            for i, curr_msec in enumerate(original_timestamps_msec[:-1]):
+                interpolated_timestamps_msec = np.arange(
+                    curr_msec + self._interpolate_step,
+                    original_timestamps_msec[i + 1],
+                    self._interpolate_step,
+                )
+
+                inter_x = func_x(interpolated_timestamps_msec)
+                inter_y = func_y(interpolated_timestamps_msec)
+                inter_z = func_z(interpolated_timestamps_msec)
+
+                inter_quat = slerp(interpolated_timestamps_msec).as_quat()
+
+                if func_vel is not None:
+                    inter_vel = func_vel(interpolated_timestamps_msec)
+                else:
+                    inter_vel = [None] * len(interpolated_timestamps_msec)
+
+                if func_acc is not None:
+                    inter_acc = func_acc(interpolated_timestamps_msec)
+                else:
+                    inter_acc = [None] * len(interpolated_timestamps_msec)
+
+                inter_prev_token = sample_anns[i]["token"]
+                inter_token = token_hex(16)
+                for j, (timestamp, x, y, z, q, vel, acc) in enumerate(
+                    zip(
+                        interpolated_timestamps_msec,
+                        inter_x,
+                        inter_y,
+                        inter_z,
+                        inter_quat,
+                        inter_vel,
+                        inter_acc,
+                    )
+                ):
+                    closest_sample = self._get_closest_timestamp(interpolated_samples, timestamp)
+                    inter_next_token = (
+                        token_hex(16)
+                        if j != len(interpolated_sample_timestamps) - 1
+                        else sample_anns[i + 1]["next"]
+                    )
+                    all_sample_annotations.append(
+                        {
+                            "token": inter_token,
+                            "sample_token": closest_sample["token"],
+                            "instance_token": ins_token,
+                            "attribute_tokens": sample_anns[i]["attribute_tokens"],
+                            "visibility_token": sample_anns[i]["visibility_token"],
+                            "translation": [x, y, z],
+                            "velocity": vel,
+                            "acceleration": acc,
+                            "size": sample_anns[i]["size"],
+                            "rotation": q.tolist(),
+                            "num_lidar_pts": sample_anns[i]["num_lidar_pts"],
+                            "num_radar_pts": sample_anns[i]["num_radar_pts"],
+                            "next": inter_next_token,
+                            "prev": inter_prev_token,
+                        }
+                    )
+                    inter_prev_token = inter_token
+                    inter_token = inter_next_token
+        return all_sample_annotations
+
+    def _get_closest_timestamp(
+        self,
+        records: List[Dict[str, Any]],
+        timestamp: float,
+    ) -> Dict[str, Any]:
+        """Get the closest element to 'timestamp' from the input list."""
+        res = min(records, key=lambda r: abs(r["timestamp"] - timestamp))
+        return res
+
+    def _save_json(self, records: Any, filename: str) -> None:
+        with open(filename, "w") as f:
+            json.dump(records, f, indent=4)

--- a/perception_dataset/t4_dataset/data_interpolator.py
+++ b/perception_dataset/t4_dataset/data_interpolator.py
@@ -166,6 +166,10 @@ class DataInterpolator(AbstractConverter):
                 for i in range(num_times - 1)
             ]
         )
+
+        if len(inter_times) == 0:
+            return all_ego_poses
+
         inter_xyz = func_xyz(inter_times)
         inter_quat = func_rot(inter_times).as_quat()
 

--- a/perception_dataset/t4_dataset/data_interpolator.py
+++ b/perception_dataset/t4_dataset/data_interpolator.py
@@ -166,9 +166,9 @@ class DataInterpolator(AbstractConverter):
             for record in nusc.sample_data
         ]
         for sd_record in all_sample_data:
-            if sd_record["is_key_frame"] or "pcd.bin" == sd_record["fileformat"]:
+            if sd_record["is_key_frame"]:
                 continue
-            filename: str = osp.splitext(osp.basename(sd_record["filename"]))[0]
+            filename: str = osp.splitext(osp.basename(sd_record["filename"].replace(".pcd.bin", ".pcd")))[0]
             if filename in interpolated_samples_dict.keys():
                 sample_token: str = interpolated_samples_dict[filename]["token"]
                 sd_record["sample_token"] = sample_token

--- a/perception_dataset/t4_dataset/data_interpolator.py
+++ b/perception_dataset/t4_dataset/data_interpolator.py
@@ -69,7 +69,7 @@ class DataInterpolator(AbstractConverter):
         super().__init__(input_base, output_base)
         self._dataset_paths = glob(osp.join(input_base, "*"))
         self._target_hz = target_hz
-        self._interpolate_step_msec = 100.0 / self._target_hz  # [msec]
+        self._interpolate_step_msec = 1000.0 / self._target_hz  # [msec]
         self.logger = configure_logger(modname=__name__) if logger is None else logger
 
     def convert(self) -> None:


### PR DESCRIPTION
## Description

<!-- Describe the changes -->
Add support of interpolating data with a specified Hz.

Interpolation updates the following records and fields
- `scene.json`: update `nbr_samples`
- `instance.json`: update `nbr_annotations`
~- `ego_pose.json`: add new record with the interpolated `timestamp/translation/rotation`~
- `sample.json`: add new record with the interpolated `timestamp`
- `sample_data.json`: update with the corresponding `sample` and set `is_key_frame=Ture`
- `sample_annotation.json`: add new record with interpolated `translation/rotation` and the corresponding `sample`

## How to review

<!-- Describe the review procedure -->

## How to test

### test data

<!-- Describe test data -->

### test command

<!-- Describe how to test this PR. -->

```bash
# interpolation
python3 -m perception_dataset.convert --config ./config/interpolate_t4.yaml

# visualize interpolated paths
python3 perception_dataset/t4_dataset/data_interpolator.py <DATA_ROOT>
```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
