### PR TITLE
feat: ensure /tf and /tf_static topics are present, and adjust frame timestamp comparison

### DIFF
--- a/perception_dataset/rosbag2/rosbag2_reader.py
+++ b/perception_dataset/rosbag2/rosbag2_reader.py
@@ -76,7 +76,7 @@ class Rosbag2Reader:
         if "/tf" not in self._topic_name_to_topic_type:
             raise ValueError(f"/tf is not in {self._bag_dir}")
         if "/tf_static" not in self._topic_name_to_topic_type:
-            raise ValueError(f"tf_static is not in {self._bag_dir}")
+            raise ValueError(f"/tf_static is not in {self._bag_dir}")
         for message in self.read_messages(topics=["/tf"]):
             for transform in message.transforms:
                 self._tf_buffer.set_transform(transform, "default_authority")

--- a/perception_dataset/rosbag2/rosbag2_reader.py
+++ b/perception_dataset/rosbag2/rosbag2_reader.py
@@ -73,6 +73,10 @@ class Rosbag2Reader:
 
     def _set_tf_buffer(self):
         """set /tf and /tf_static to tf_buffer"""
+        if "/tf" not in self._topic_name_to_topic_type:
+            raise ValueError(f"/tf is not in {self._bag_dir}")
+        if "/tf_static" not in self._topic_name_to_topic_type:
+            raise ValueError(f"tf_static is not in {self._bag_dir}")
         for message in self.read_messages(topics=["/tf"]):
             for transform in message.transforms:
                 self._tf_buffer.set_transform(transform, "default_authority")

--- a/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
@@ -608,7 +608,9 @@ class _Rosbag2ToNonAnnotatedT4Converter:
                 lidar_unix_timestamp = misc_utils.nusc_timestamp_to_unix_timestamp(
                     sample_record.timestamp
                 )
-                while (image_unix_timestamp - prev_frame_unix_timestamp) > self._TIMESTAMP_DIFF:
+                while (
+                    image_unix_timestamp - prev_frame_unix_timestamp
+                ) > self._camera_latency + self._TIMESTAMP_DIFF:
                     dummy_image_timestamp = self._insert_dummy_image_frame(
                         image_msg,
                         sensor_channel,


### PR DESCRIPTION
## Description
* fix: ensure /tf and /tf_static topics are present in Rosbag2Reader
* adjust frame timestamp comparison in _Rosbag2ToNonAnnotatedT4Converter


<!-- Describe the changes -->

## How to review
Ensure that the CI tests are passing.
<!-- Describe the review procedure -->

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
