### PR TITLE
feat(deepen_to_t4): accept frames without attribute

### DIFF
--- a/perception_dataset/deepen/deepen_to_t4_converter.py
+++ b/perception_dataset/deepen/deepen_to_t4_converter.py
@@ -207,20 +207,19 @@ class DeepenToT4Converter(AbstractConverter):
             anno_label_category_id: str = label_dict["label_category_id"]
             anno_label_id: str = label_dict["label_id"]
             # in case the attributes is not set
+            visibility: str = "Not available"
             if "attributes" not in label_dict:
                 anno_attributes = {}
             else:
                 anno_attributes: Dict[str, str] = label_dict["attributes"]
-            if "Occlusion_State" in anno_attributes:
-                visibility: str = self._convert_occulusion_to_visibility(
-                    anno_attributes["Occlusion_State"]
-                )
-            elif "occlusion_state" in anno_attributes:
-                visibility: str = self._convert_occulusion_to_visibility(
-                    anno_attributes["occlusion_state"]
-                )
-            else:
-                visibility: str = "Not available"
+                if "Occlusion_State" in anno_attributes:
+                    visibility = self._convert_occulusion_to_visibility(
+                        anno_attributes["Occlusion_State"]
+                    )
+                elif "occlusion_state" in anno_attributes:
+                    visibility = self._convert_occulusion_to_visibility(
+                        anno_attributes["occlusion_state"]
+                    )
             label_t4_dict: Dict[str, Any] = {
                 "category_name": anno_label_category_id,
                 "instance_id": anno_label_id,


### PR DESCRIPTION
## Description

Accept objects without attributes.
Previously, if there were no attributes, it makes an error. This change prevents such errors.
<!-- Describe the changes -->

## How to review

<!-- Describe the review procedure -->

## How to test

### test data

<!-- Describe test data -->

### test command

<!-- Describe how to test this PR. -->

```bash
python -m perception_dataset.convert --config config/convert_rosbag2_to_non_annotated_t4_sample.yaml

```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
