### PR TITLE
fix: update `TrafficSignal` to `TrafficLight`

### DIFF
--- a/perception_dataset/rosbag2/autoware_msgs.py
+++ b/perception_dataset/rosbag2/autoware_msgs.py
@@ -9,11 +9,11 @@ from autoware_auto_perception_msgs.msg import (
     TrackedObjects,
 )
 from tier4_perception_msgs.msg import (
+    TrafficLight,
+    TrafficLightArray,
     TrafficLightElement,
     TrafficLightRoi,
     TrafficLightRoiArray,
-    TrafficSignal,
-    TrafficSignalArray,
 )
 
 DEFAULT_ATTRIBUTES_BY_CATEGORY_NAME: Dict[str, List[str]] = {
@@ -198,7 +198,7 @@ def parse_perception_objects(msg) -> List[Dict[str, Any]]:
 
 
 def parse_traffic_lights(
-    roi_msg: TrafficLightRoiArray, signal_msg: TrafficSignalArray
+    roi_msg: TrafficLightRoiArray, signal_msg: TrafficLightArray
 ) -> List[Dict[str, Any]]:
     """https://github.com/tier4/autoware_auto_msgs/tree/tier4/main/autoware_auto_perception_msgs
 
@@ -226,7 +226,7 @@ def parse_traffic_lights(
         TrafficLightElement.UP_ARROW: "straight",
     }
 
-    def get_category_name(signal: TrafficSignal):
+    def get_category_name(signal: TrafficLight):
         # list for saving the status of the lights
         blubs: List[int] = []
 
@@ -263,14 +263,14 @@ def parse_traffic_lights(
         roi_msg, TrafficLightRoiArray
     ), f"Invalid object message type: {type(roi_msg)}"
     assert isinstance(
-        signal_msg, TrafficSignalArray
+        signal_msg, TrafficLightArray
     ), f"Invalid object message type: {type(signal_msg)}"
 
     scene_annotation_list: List[Dict[str, Any]] = []
     for roi in roi_msg.rois:
         roi: TrafficLightRoi
         for signal in signal_msg.signals:
-            signal: TrafficSignal
+            signal: TrafficLight
             if roi.traffic_light_id == signal.traffic_light_id:
                 category_name = get_category_name(signal)
                 label_dict: Dict[str, Any] = {

--- a/perception_dataset/rosbag2/autoware_msgs.py
+++ b/perception_dataset/rosbag2/autoware_msgs.py
@@ -198,7 +198,7 @@ def parse_perception_objects(msg) -> List[Dict[str, Any]]:
 
 
 def parse_traffic_lights(
-    roi_msg: TrafficLightRoiArray, signal_msg: TrafficLightArray
+    roi_msg: TrafficLightRoiArray, traffic_light_array_msg: TrafficLightArray
 ) -> List[Dict[str, Any]]:
     """https://github.com/tier4/autoware_auto_msgs/tree/tier4/main/autoware_auto_perception_msgs
 
@@ -263,13 +263,13 @@ def parse_traffic_lights(
         roi_msg, TrafficLightRoiArray
     ), f"Invalid object message type: {type(roi_msg)}"
     assert isinstance(
-        signal_msg, TrafficLightArray
-    ), f"Invalid object message type: {type(signal_msg)}"
+        traffic_light_array_msg, TrafficLightArray
+    ), f"Invalid object message type: {type(traffic_light_array_msg)}"
 
     scene_annotation_list: List[Dict[str, Any]] = []
     for roi in roi_msg.rois:
         roi: TrafficLightRoi
-        for signal in signal_msg.signals:
+        for signal in traffic_light_array_msg.signals:
             signal: TrafficLight
             if roi.traffic_light_id == signal.traffic_light_id:
                 category_name = get_category_name(signal)

--- a/perception_dataset/rosbag2/rosbag2_to_annotated_t4_tlr_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_annotated_t4_tlr_converter.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Set, Union
 import numpy as np
 from pycocotools import mask as cocomask
 from sensor_msgs.msg import CompressedImage
-from tier4_perception_msgs.msg import TrafficLightRoiArray, TrafficSignalArray
+from tier4_perception_msgs.msg import TrafficLightArray, TrafficLightRoiArray
 import yaml
 
 from perception_dataset.rosbag2.autoware_msgs import parse_traffic_lights
@@ -52,7 +52,7 @@ class _Rosbag2ToAnnotatedT4TlrConverter(_Rosbag2ToT4Converter):
         self._traffic_light_rois_topic_name: str = params.traffic_light_rois_topic_name
         # traffic light lists
         self._traffic_light_roi_msgs: List[TrafficLightRoiArray] = []
-        self._traffic_light_label_msgs: List[TrafficSignalArray] = []
+        self._traffic_light_label_msgs: List[TrafficLightArray] = []
         # timestamps when there are traffic lights being detected
         self._non_empty_timestamps: Set[float] = set()
 
@@ -250,12 +250,12 @@ class _Rosbag2ToAnnotatedT4TlrConverter(_Rosbag2ToT4Converter):
         )
 
     def _process_traffic_lights(
-        self, message: Union[TrafficLightRoiArray, TrafficSignalArray]
+        self, message: Union[TrafficLightRoiArray, TrafficLightArray]
     ) -> List[Dict[str, Any]]:
         """
         Args:
           message: autoware_auto_perception_msgs.msg.TrafficLightRoiArray
-            or autoware_auto_perception_msgs.msg.TrafficSignalArray
+            or autoware_auto_perception_msgs.msg.TrafficLightArray
         Returns:
             List[Dict[str, Any]]: dict format
         """
@@ -269,7 +269,7 @@ class _Rosbag2ToAnnotatedT4TlrConverter(_Rosbag2ToT4Converter):
                     self._traffic_light_label_msgs.remove(label)
                     return res
             self._traffic_light_roi_msgs.append(message)
-        elif isinstance(message, TrafficSignalArray):
+        elif isinstance(message, TrafficLightArray):
             for roi in self._traffic_light_roi_msgs:
                 if (
                     roi.header.stamp.sec == message.header.stamp.sec

--- a/perception_dataset/rosbag2/rosbag2_to_annotated_t4_tlr_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_annotated_t4_tlr_converter.py
@@ -255,7 +255,7 @@ class _Rosbag2ToAnnotatedT4TlrConverter(_Rosbag2ToT4Converter):
         """
         Args:
           message: autoware_auto_perception_msgs.msg.TrafficLightRoiArray
-            or autoware_auto_perception_msgs.msg.TrafficLightArray
+            or autoware_auto_perception_msgs.msg.TrafficSignalArray
         Returns:
             List[Dict[str, Any]]: dict format
         """


### PR DESCRIPTION
## Description

<!-- Describe the changes -->

According to https://github.com/tier4/tier4_autoware_msgs/pull/112, `TrafficSignal` and `TrafficSignalArray` have been renamed into `TrafficLight` and `TrafficLightArray` respectively. This PR updates them.

## How to review

<!-- Describe the review procedure -->

## How to test

### test data

<!-- Describe test data -->

### test command

<!-- Describe how to test this PR. -->

```bash

```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
