### PR TITLE
feat: add fastlabel-2D to t4dataset converter

### DIFF
--- a/config/convert_fastlabel_2d_to_t4.yaml
+++ b/config/convert_fastlabel_2d_to_t4.yaml
@@ -1,0 +1,27 @@
+task: convert_fastlabel_2d_to_t4
+description:
+  visibility:
+    full: "No occlusion of the object."
+    most: "Object is occluded, but by less than 50%."
+    partial: "The object is occluded by more than 50% (but not completely)."
+    none: "The object is 90-100% occluded and no points/pixels are visible in the label."
+  camera_index:
+    CAM_FRONT: 0
+    CAM_FRONT_RIGHT: 1
+    CAM_BACK_RIGHT: 2
+    CAM_BACK: 3
+    CAM_BACK_LEFT: 4
+    CAM_FRONT_LEFT: 5
+
+conversion:
+  input_base: ./data/non_annotated_t4_format
+  input_anno_base: ./data/fastlabel
+  input_bag_base: ./data/rosbag2
+  output_base: ./data/t4_format
+  topic_list: ./config/topic_list_sample.yaml
+  dataset_corresponding:
+    # input t4dataset_name: FastLabel json file name
+    2-4: 2-4.json
+    2-6: 2-6.json
+    4-6-2: 4-6-2.json
+    6-1: 6-1.json

--- a/config/convert_fastlabel_2d_to_t4.yaml
+++ b/config/convert_fastlabel_2d_to_t4.yaml
@@ -14,14 +14,11 @@ description:
     CAM_FRONT_LEFT: 5
 
 conversion:
-  input_base: ./data/non_annotated_t4_format
+  input_base: ./data/non_annotated_t4_format  # could be non_annotated_t4_format or t4_format_3d_annotated
   input_anno_base: ./data/fastlabel
   input_bag_base: ./data/rosbag2
-  output_base: ./data/t4_format
+  output_base: ./data/t4_format_2d_annotated  # this only includes the 2D annotations
   topic_list: ./config/topic_list_sample.yaml
   dataset_corresponding:
     # input t4dataset_name: FastLabel json file name
-    2-4: 2-4.json
-    2-6: 2-6.json
-    4-6-2: 4-6-2.json
-    6-1: 6-1.json
+    DBv2.0-2-4: 2-4.json

--- a/docs/tools_overview.md
+++ b/docs/tools_overview.md
@@ -130,10 +130,12 @@ python -m perception_dataset.convert --config config/convert_deepen_to_t4_sample
 
 ## FastLabel
 
+This step converts FastLabel 2D annotations to T4 format (2D only).
+
 ### Conversion from FastLabel JSON Format to T4 Format
 
-input: T4 format data (annotated or non-annotated) + FastLabel annotations (JSON format)
-output: T4 format data
+input: T4 format data (3D annotated or non-annotated) + FastLabel annotations (JSON format)  
+output: T4 format data (2D annotated)
 
 ```bash
 python -m perception_dataset.convert --config config/convert_fastlabel_2d_to_t4.yaml

--- a/docs/tools_overview.md
+++ b/docs/tools_overview.md
@@ -128,6 +128,18 @@ output: T4 format data
 python -m perception_dataset.convert --config config/convert_deepen_to_t4_sample.yaml
 ```
 
+## FastLabel
+
+### Conversion from FastLabel JSON Format to T4 Format
+
+input: T4 format data (annotated or non-annotated) + FastLabel annotations (JSON format)
+output: T4 format data
+
+```bash
+python -m perception_dataset.convert --config config/convert_fastlabel_2d_to_t4.yaml
+# To overwrite T4-format data, use the --overwrite option
+```
+
 ## Rosbag with objects
 
 ### Synthetic bag to T4 format

--- a/perception_dataset/convert.py
+++ b/perception_dataset/convert.py
@@ -313,7 +313,10 @@ def main():
         logger.info(f"[DONE] Interpolating {input_base} into {output_base}")
 
     elif task == "convert_fastlabel_2d_to_t4":
-        from perception_dataset.fastlabel_to_t4.fastlabel_2d_to_t4_converter import FastLabel2dToT4Converter
+        from perception_dataset.fastlabel_to_t4.fastlabel_2d_to_t4_converter import (
+            FastLabel2dToT4Converter,
+        )
+
         input_base = config_dict["conversion"]["input_base"]
         output_base = config_dict["conversion"]["output_base"]
         input_anno_base = config_dict["conversion"]["input_anno_base"]

--- a/perception_dataset/convert.py
+++ b/perception_dataset/convert.py
@@ -312,6 +312,31 @@ def main():
         converter.convert()
         logger.info(f"[DONE] Interpolating {input_base} into {output_base}")
 
+    elif task == "convert_fastlabel_2d_to_t4":
+        from perception_dataset.fastlabel_to_t4.fastlabel_2d_to_t4_converter import FastLabel2dToT4Converter
+        input_base = config_dict["conversion"]["input_base"]
+        output_base = config_dict["conversion"]["output_base"]
+        input_anno_base = config_dict["conversion"]["input_anno_base"]
+        dataset_corresponding = config_dict["conversion"]["dataset_corresponding"]
+        description = config_dict["description"]
+        input_bag_base = config_dict["conversion"]["input_bag_base"]
+        topic_list_yaml_path = config_dict["conversion"]["topic_list"]
+        with open(topic_list_yaml_path) as f:
+            topic_list_yaml = yaml.safe_load(f)
+
+        converter = FastLabel2dToT4Converter(
+            input_base=input_base,
+            output_base=output_base,
+            input_anno_base=input_anno_base,
+            dataset_corresponding=dataset_corresponding,
+            overwrite_mode=args.overwrite,
+            description=description,
+            input_bag_base=input_bag_base,
+            topic_list=topic_list_yaml,
+        )
+        logger.info(f"[BEGIN] Converting Fastlabel data ({input_base}) to T4 data ({output_base})")
+        converter.convert()
+        logger.info(f"[END] Converting Fastlabel data ({input_base}) to T4 data ({output_base})")
     else:
         raise NotImplementedError()
 

--- a/perception_dataset/deepen/deepen_to_t4_converter.py
+++ b/perception_dataset/deepen/deepen_to_t4_converter.py
@@ -207,7 +207,8 @@ class DeepenToT4Converter(AbstractConverter):
             anno_label_category_id: str = label_dict["label_category_id"]
             anno_label_id: str = label_dict["label_id"]
             # in case the attributes is not set
-            if "attributes" not in label_dict:
+            if "attributes" not in label_dict or label_dict["attributes"] is None:
+                logger.warning(f"attributes is not set in {label_dict}")
                 anno_attributes = {}
             else:
                 anno_attributes: Dict[str, str] = label_dict["attributes"]

--- a/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
+++ b/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
@@ -1,0 +1,205 @@
+from collections import defaultdict
+import glob
+import json
+import os.path as osp
+from pathlib import Path
+import shutil
+from typing import Any, Dict, List, Optional, Union
+from nuimages import NuImages
+from nuscenes import NuScenes
+
+from perception_dataset.deepen.deepen_to_t4_converter import DeepenToT4Converter
+from perception_dataset.t4_dataset.annotation_files_generator import AnnotationFilesGenerator
+from perception_dataset.utils.logger import configure_logger
+
+logger = configure_logger(modname=__name__)
+
+
+class FastLabel2dToT4Converter(DeepenToT4Converter):
+    def __init__(
+        self,
+        input_base: str,
+        output_base: str,
+        input_anno_base: str,
+        dataset_corresponding: Dict[str, int],
+        overwrite_mode: bool,
+        description: Dict[str, Dict[str, str]],
+        input_bag_base: Optional[str],
+        topic_list: Union[Dict[str, List[str]], List[str]],
+    ):
+        super().__init__(
+            input_base,
+            output_base,
+            input_anno_base,
+            dataset_corresponding=None,
+            overwrite_mode=overwrite_mode,
+            description=description,
+            input_bag_base=input_bag_base,
+            topic_list=topic_list,
+            t4_dataset_dir_name=None,
+            ignore_interpolate_label=False,
+        )
+        self._input_base = Path(input_base)
+        self._output_base = Path(output_base)
+        self._t4dataset_name_to_merge: Dict[str, str] = dataset_corresponding
+        self._camera2idx = description.get("camera_index")
+        self._input_anno_files: List[Path] = []
+        for f in Path(input_anno_base).rglob("*.json"):
+            self._input_anno_files.append(f)
+
+    def convert(self):
+        # Load and format Fastlabel annotations
+        anno_jsons_dict = self._load_annotation_jsons()
+        fl_annotations = self._format_fastlabel_annotation(anno_jsons_dict)
+
+        for t4dataset_name in fl_annotations.keys():
+            input_dir = self._input_base / t4dataset_name
+            input_annotation_dir = input_dir / "annotation"
+            if not osp.exists(input_annotation_dir):
+                logger.warning(f"input_dir {input_dir} not exists.")
+                continue
+
+            output_dir = self._output_base / t4dataset_name
+            output_dir = output_dir / "t4_dataset"
+            if self._input_bag_base is not None:
+                input_bag_dir = Path(self._input_bag_base) / t4dataset_name
+            if osp.exists(output_dir):
+                logger.error(f"{output_dir} already exists.")
+                is_dir_exist = True
+            if self._overwrite_mode or not is_dir_exist:
+                # Remove existing output directory
+                shutil.rmtree(output_dir, ignore_errors=True)
+                # Copy input data to output directory
+                self._copy_data(input_dir, output_dir)
+                # Make rosbag
+                if self._input_bag_base is not None:
+                    self._find_start_end_time(input_dir)
+                    self._make_rosbag(str(input_bag_dir), str(output_dir))
+            else:
+                raise ValueError("If you want to overwrite files, use --overwrite option.")
+
+            annotation_files_generator = AnnotationFilesGenerator(description=self._description)
+            annotation_files_generator.convert_one_scene(
+                input_dir=input_dir,
+                output_dir=output_dir,
+                scene_anno_dict=fl_annotations[t4dataset_name],
+                dataset_name=t4dataset_name,
+            )
+
+
+
+
+
+    def _load_annotation_jsons(self):
+        """Load annotations from all JSON files in the input directory and return as a dictionary."""
+        anno_dict = {}
+        for file in self._input_anno_files:
+            with open(file) as f:
+                anno_dict[file.name] = json.load(f)
+        return anno_dict
+
+    def _format_fastlabel_annotation(self, annotations):
+        """
+        e.g. of input_anno_file(fastlabel):
+        "DBv2.0_1-1.json": [
+        {
+            "name": "CAM_BACK/0.png",
+            "width": 1440,
+            "height": 1080,
+            "annotations": [
+            {
+                "type": "bbox",
+                "title": "pedestrian.adult",
+                "value": "adult",
+                "color": "#91EEFB",
+                "attributes": [
+                {
+                    "type": "text",
+                    "name": "ID",
+                    "key": "id",
+                    "value": "cc0cc1eb4cc15118d10ee42f0426cc00"
+                },
+                {
+                    "type": "frameSelect",
+                    "name": "Occlusion_State_none",
+                    "key": "occlusion_state_none",
+                    "value": []
+                },
+                {
+                    "type": "frameSelect",
+                    "name": "Occlusion_State_partial",
+                    "key": "occlusion_state_partial",
+                    "value": [
+                    [
+                        1,
+                        9
+                    ]
+                    ]
+                },
+                {
+                    "type": "frameSelect",
+                    "name": "Occlusion_State_most",
+                    "key": "occlusion_state_most",
+                    "value": [
+                    [
+                        10,
+                        19
+                    ]
+                    ]
+                }
+                ],
+                "annotations": [
+                {
+                    "points": [
+                    1221.25,
+                    488.44,
+                    1275.38,
+                    570.47
+                    ],
+                    "rotation": 0,
+                    "autogenerated": false
+                }
+                ]
+            },
+        },
+        ....
+        ],
+        ....
+        """
+        fl_annotations = {}
+
+        for filename, ann_list in annotations.items():
+            dataset_name = Path(filename).stem
+            for ann in ann_list:
+                filename = ann["name"].split("/")[-1]
+                file_id = int(filename.split(".")[0])
+                frame_no = file_id + 1
+                camera = ann["name"].split("/")[-2]
+
+                if dataset_name not in fl_annotations:
+                    fl_annotations[dataset_name] = defaultdict(list)
+
+                for a in ann["annotations"]:
+                    occlusion_state = "occlusion_state.none"
+                    for att in a["attributes"]:
+                        if att["key"] == "id":
+                            instance_id = att["value"]
+                        if "occlusion_state" in att["key"]:
+                            for v in att["value"]:
+                                if frame_no in range(v[0], v[1]):
+                                    occlusion_state = "occlusion_state." + att["key"].split("_")[-1]
+                                    break
+                    label_t4_dict: Dict[str, Any] = {
+                        "category_name": a["title"],
+                        "instance_id": instance_id,
+                        "attribute_names": [occlusion_state],
+                    }
+                    label_t4_dict.update(
+                        {
+                            "two_d_box": a["annotations"][0]["points"],
+                            "sensor_id": self._camera2idx[camera],
+                        }
+                    )
+                    fl_annotations[dataset_name][file_id].append(label_t4_dict)
+
+        return fl_annotations

--- a/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
+++ b/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
@@ -54,12 +54,14 @@ class FastLabel2dToT4Converter(DeepenToT4Converter):
         fl_annotations = self._format_fastlabel_annotation(anno_jsons_dict)
 
         for t4dataset_name in fl_annotations.keys():
+            # Check if input directory exists
             input_dir = self._input_base / t4dataset_name
             input_annotation_dir = input_dir / "annotation"
             if not osp.exists(input_annotation_dir):
                 logger.warning(f"input_dir {input_dir} not exists.")
                 continue
 
+            # Check if output directory already exists
             output_dir = self._output_base / t4dataset_name
             output_dir = output_dir / "t4_dataset"
             if self._input_bag_base is not None:
@@ -79,6 +81,7 @@ class FastLabel2dToT4Converter(DeepenToT4Converter):
             else:
                 raise ValueError("If you want to overwrite files, use --overwrite option.")
 
+            # Start converting annotations
             annotation_files_generator = AnnotationFilesGenerator(description=self._description)
             annotation_files_generator.convert_one_scene(
                 input_dir=input_dir,

--- a/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
+++ b/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
@@ -1,13 +1,9 @@
 from collections import defaultdict
-import glob
 import json
 import os.path as osp
 from pathlib import Path
 import shutil
 from typing import Any, Dict, List, Optional, Union
-
-from nuimages import NuImages
-from nuscenes import NuScenes
 
 from perception_dataset.deepen.deepen_to_t4_converter import DeepenToT4Converter
 from perception_dataset.t4_dataset.annotation_files_generator import AnnotationFilesGenerator

--- a/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
+++ b/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
@@ -49,7 +49,7 @@ class FastLabel2dToT4Converter(DeepenToT4Converter):
         anno_jsons_dict = self._load_annotation_jsons()
         fl_annotations = self._format_fastlabel_annotation(anno_jsons_dict)
 
-        for t4dataset_name in fl_annotations.keys():
+        for t4dataset_name in self._t4dataset_name_to_merge.keys():
             # Check if input directory exists
             input_dir = self._input_base / t4dataset_name
             input_annotation_dir = input_dir / "annotation"
@@ -71,7 +71,9 @@ class FastLabel2dToT4Converter(DeepenToT4Converter):
                 # Copy input data to output directory
                 self._copy_data(input_dir, output_dir)
                 # Make rosbag
-                if self._input_bag_base is not None:
+                if self._input_bag_base is not None and not osp.exists(
+                    osp.join(output_dir, "input_bag")
+                ):
                     self._find_start_end_time(input_dir)
                     self._make_rosbag(str(input_bag_dir), str(output_dir))
             else:
@@ -164,7 +166,7 @@ class FastLabel2dToT4Converter(DeepenToT4Converter):
         """
         fl_annotations = {}
 
-        for filename, ann_list in annotations.items():
+        for filename, ann_list in sorted(annotations.items()):
             dataset_name = Path(filename).stem
             for ann in ann_list:
                 filename = ann["name"].split("/")[-1]

--- a/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
+++ b/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
@@ -5,6 +5,7 @@ import os.path as osp
 from pathlib import Path
 import shutil
 from typing import Any, Dict, List, Optional, Union
+
 from nuimages import NuImages
 from nuscenes import NuScenes
 
@@ -85,10 +86,6 @@ class FastLabel2dToT4Converter(DeepenToT4Converter):
                 scene_anno_dict=fl_annotations[t4dataset_name],
                 dataset_name=t4dataset_name,
             )
-
-
-
-
 
     def _load_annotation_jsons(self):
         """Load annotations from all JSON files in the input directory and return as a dictionary."""
@@ -187,7 +184,9 @@ class FastLabel2dToT4Converter(DeepenToT4Converter):
                         if "occlusion_state" in att["key"]:
                             for v in att["value"]:
                                 if frame_no in range(v[0], v[1]):
-                                    occlusion_state = "occlusion_state." + att["key"].split("_")[-1]
+                                    occlusion_state = (
+                                        "occlusion_state." + att["key"].split("_")[-1]
+                                    )
                                     break
                     label_t4_dict: Dict[str, Any] = {
                         "category_name": a["title"],

--- a/perception_dataset/t4_dataset/annotation_files_generator.py
+++ b/perception_dataset/t4_dataset/annotation_files_generator.py
@@ -99,6 +99,7 @@ class AnnotationFilesGenerator:
             for anno in anno_list:
                 if "two_d_box" in anno.keys():
                     has_2d_annotation = True
+                    break
 
         if has_2d_annotation:
             for frame_index_nuim, sample_nuim in enumerate(nuim.sample_data):
@@ -227,9 +228,11 @@ class AnnotationFilesGenerator:
         """
         for frame_index in sorted(scene_anno_dict.keys()):
             anno_list: List[Dict[str, Any]] = scene_anno_dict[frame_index]
+            # in case of the first frame in annotation is not 0
+            min_frame_index: int = min(scene_anno_dict.keys())
 
             # for the case that the frame_index is not in the sample_token
-            if frame_index not in frame_index_to_sample_token:
+            if frame_index - min_frame_index not in frame_index_to_sample_token:
                 print(f"frame_index {frame_index} in annotation.json is not in sample_token")
                 continue
 

--- a/perception_dataset/t4_dataset/classes/instance.py
+++ b/perception_dataset/t4_dataset/classes/instance.py
@@ -13,6 +13,11 @@ class InstanceRecord(AbstractRecord):
         self._first_annotation_token: str = ""
         self._last_annotation_token: str = ""
 
+        # If the instance_name is a token, then it is a valid token
+        orig_instance_id = instance_name.split("::")[-1]
+        if len(orig_instance_id) == 32:
+            self._token = orig_instance_id
+
     def to_dict(self) -> Dict[str, Any]:
         d = {
             "token": self.token,


### PR DESCRIPTION
## Description

<!-- Describe the changes -->
This PR adds functionality to convert annotations from Fastlabel annotation JSON to T4 dataset. This enables conversion of annotations created in Fastlabel to T4 format.

Changes:

- Added functionality to convert annotations from FastLabel 2D annotation JSON to T4 dataset (2D only).
- Updated the documentation to include information about the new feature.

## How to review

<!-- Describe the review procedure -->

## How to test
Please review that the 2D bounding boxes are correctly assigned.
Check the dataset visualization videos: https://drive.google.com/drive/u/0/folders/1dmVG76D-tLPuEc2Aa423CHXhYRY6bC3X

### test data

<!-- Describe test data -->
test data
FastLabel JSON files: https://drive.google.com/drive/folders/1k4Jp2x8LDwbrTTH-6lvmBuYOmxtJylaJ
Use with T4 dataset DBv2.0.
### test command

<!-- Describe how to test this PR. -->

```bash
python -m perception_dataset.convert --config config/convert_fastlabel_2dlink_to_t4.yaml --overwrite 
```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
