### PR TITLE
fix: modify key name and add option to exclude copying

### DIFF
--- a/config/interpolate_t4.yaml
+++ b/config/interpolate_t4.yaml
@@ -4,3 +4,4 @@ description:
 conversion:
   input_base: ./data/t4_dataset
   output_base: ./data/interpolate
+  copy_excludes: ["data", "input_bag", "pointcloud_map*"]

--- a/docs/tasks/interpolate.md
+++ b/docs/tasks/interpolate.md
@@ -81,8 +81,9 @@ task: interpolate                   ...Task name
 description:
   scene: "Interpolate"              ...Scene description
 conversion:
-  input_base: ./data/t4_dataset     ...Input base directory path
-  output_base: ./data/interpolate   ...Output base directory path
+  input_base: str     ...Input base directory path
+  output_base: str   ...Output base directory path
+  copy_excludes: list[str] | null  ...Patterns excluded to copy. If excludes nothing, set `null`.
 ```
 
 ## Check Interpolation Result

--- a/perception_dataset/convert.py
+++ b/perception_dataset/convert.py
@@ -299,12 +299,14 @@ def main():
     elif task == "interpolate":
         from perception_dataset.t4_dataset.data_interpolator import DataInterpolator
 
-        input_base = config_dict["conversion"]["input_base"]
-        output_base = config_dict["conversion"]["output_base"]
+        input_base: str = config_dict["conversion"]["input_base"]
+        output_base: str = config_dict["conversion"]["output_base"]
+        copy_excludes: list[str] | None = config_dict["conversion"].get("copy_excludes", None)
 
         converter = DataInterpolator(
             input_base=input_base,
             output_base=output_base,
+            copy_excludes=copy_excludes,
             logger=logger,
         )
 

--- a/perception_dataset/t4_dataset/data_interpolator.py
+++ b/perception_dataset/t4_dataset/data_interpolator.py
@@ -154,7 +154,7 @@ class DataInterpolator(AbstractConverter):
         prev_token: str = ""
         for i, sample_record in enumerate(all_sorted_samples[:-1]):
             next_sample_token = all_sorted_samples[i + 1]["token"]
-            sample_record["prev_token"] = prev_token
+            sample_record["prev"] = prev_token
             sample_record["next"] = next_sample_token
             prev_token = sample_record["token"]
         all_sorted_samples[-1]["prev"] = prev_token

--- a/perception_dataset/t4_dataset/data_interpolator.py
+++ b/perception_dataset/t4_dataset/data_interpolator.py
@@ -94,7 +94,7 @@ class DataInterpolator(AbstractConverter):
         output_path = osp.join(self._output_base, dataset_id)
         os.makedirs(output_path, exist_ok=True)
 
-        command: list[str] = ["rsync", "-av"]
+        command: list[str] = ["rsync", "-ahuv"]
         if self.copy_excludes is not None:
             assert isinstance(self.copy_excludes, list), f"Unexpected type of excludes: {type(self.copy_excludes)}"
             for e in self.copy_excludes:


### PR DESCRIPTION
## Description

<!-- Describe the changes -->

- modify wrong key `prev_token` to `prev` in `sample.json`
- add support of excluding to copy specified patterns which helps making copy faster
  - skip copying `data`, `input_bag`, `pointcloud_map*` by default

## How to review

<!-- Describe the review procedure -->

## How to test

### test data

<!-- Describe test data -->

### test command

<!-- Describe how to test this PR. -->

```bash
$ python3 -m perception_dataset.convert --config ./config/interpolate_t4.yaml
```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
