### PR TITLE
feat: merge T4 Datasets with 2D Camera annotations and 3D LiDAR annotations

### DIFF
--- a/config/label/attribute.yaml
+++ b/config/label/attribute.yaml
@@ -1,4 +1,5 @@
 pedestrian_state:
+    # The word `siting` is a typo included intentionally since the existing T4dataset also had the same typo.
     sitting: [pedestrian_state.sitting_lying_down, pedestrian_state.siting_lying_down, pedestrian_state.sitting]
     lying_down: [pedestrian_state.lying_down]
     standing: [pedestrian_state.standing, pedestrian_state.moving]

--- a/config/label/attribute.yaml
+++ b/config/label/attribute.yaml
@@ -1,5 +1,5 @@
 pedestrian_state:
-    sitting: [pedestrian_state.sitting_lying_down, pedestrian_state.sitting]
+    sitting: [pedestrian_state.sitting_lying_down, pedestrian_state.siting_lying_down, pedestrian_state.sitting]
     lying_down: [pedestrian_state.lying_down]
     standing: [pedestrian_state.standing, pedestrian_state.moving]
 vehicle_state:
@@ -24,6 +24,7 @@ extremities_state:
 emergency_vehicle_lights_state:
     on: [emergency_vehicle_lights_state.on]
     off: [emergency_vehicle_lights_state.off]
+    unknown: [emergency_vehicle_lights_state.unknown]
 object_state:
     still: [object_state.still]
 truncation_state:

--- a/config/merge_2d_t4dataset_to_3d.yaml
+++ b/config/merge_2d_t4dataset_to_3d.yaml
@@ -1,0 +1,7 @@
+task: merge_2d_t4dataset_to_3d
+conversion:
+  input_base: data/t4_format_2d_only
+  output_base: data/t4_format_3d_only
+  dataset_corresponding:
+    # output 3D dataset name: input 2D dataset name
+    # (e.g.)DBv2.0_1-1_3d: DBv2.0_1-1_2d

--- a/docs/tools_overview.md
+++ b/docs/tools_overview.md
@@ -130,9 +130,9 @@ python -m perception_dataset.convert --config config/convert_deepen_to_t4_sample
 
 ## FastLabel
 
-This step converts FastLabel 2D annotations to T4 format (2D only).
-
 ### Conversion from FastLabel JSON Format to T4 Format
+
+This step converts FastLabel 2D annotations to T4 format (2D only).
 
 input: T4 format data (3D annotated or non-annotated) + FastLabel annotations (JSON format)  
 output: T4 format data (2D annotated)
@@ -140,6 +140,16 @@ output: T4 format data (2D annotated)
 ```bash
 python -m perception_dataset.convert --config config/convert_fastlabel_2d_to_t4.yaml
 # To overwrite T4-format data, use the --overwrite option
+```
+
+### Merge 2D T4 format data into 3D T4 format data
+This step merges 2D-id-linked T4 format dataset into originally 3D-labeled T4 format data.
+
+input: T4 format data (3D annotated) + T4 format data (2D annotated/ID-linked)  
+output: T4 format data (2D&3D annotated)
+
+```bash
+python -m perception_dataset.convert --config config/merge_2d_t4dataset_to_3d.yaml
 ```
 
 ## Rosbag with objects

--- a/docs/tools_overview.md
+++ b/docs/tools_overview.md
@@ -143,6 +143,7 @@ python -m perception_dataset.convert --config config/convert_fastlabel_2d_to_t4.
 ```
 
 ### Merge 2D T4 format data into 3D T4 format data
+
 This step merges 2D-id-linked T4 format dataset into originally 3D-labeled T4 format data.
 
 input: T4 format data (3D annotated) + T4 format data (2D annotated/ID-linked)  

--- a/perception_dataset/convert.py
+++ b/perception_dataset/convert.py
@@ -342,6 +342,25 @@ def main():
         logger.info(f"[BEGIN] Converting Fastlabel data ({input_base}) to T4 data ({output_base})")
         converter.convert()
         logger.info(f"[END] Converting Fastlabel data ({input_base}) to T4 data ({output_base})")
+
+    elif task == "merge_2d_t4dataset_to_3d":
+        from perception_dataset.t4_dataset.t4_dataset_2d3d_merger import T4dataset2D3DMerger
+
+        input_base = config_dict["conversion"]["input_base"]
+        output_base = config_dict["conversion"]["output_base"]
+        dataset_corresponding = config_dict["conversion"]["dataset_corresponding"]
+
+        converter = T4dataset2D3DMerger(
+            input_base=input_base,
+            output_base=output_base,
+            overwrite_mode=args.overwrite,
+            dataset_corresponding=dataset_corresponding,
+        )
+
+        logger.info(f"[BEGIN] Merging T4 dataset ({input_base}) into T4 dataset ({output_base})")
+        converter.convert()
+        logger.info(f"[Done] Merging T4 dataset ({input_base}) into T4 dataset ({output_base})")
+
     else:
         raise NotImplementedError()
 

--- a/perception_dataset/convert.py
+++ b/perception_dataset/convert.py
@@ -353,7 +353,6 @@ def main():
         converter = T4dataset2D3DMerger(
             input_base=input_base,
             output_base=output_base,
-            overwrite_mode=args.overwrite,
             dataset_corresponding=dataset_corresponding,
         )
 

--- a/perception_dataset/t4_dataset/t4_dataset_2d3d_merger.py
+++ b/perception_dataset/t4_dataset/t4_dataset_2d3d_merger.py
@@ -24,6 +24,7 @@ class T4dataset2D3DMerger(AbstractConverter):
 
     def convert(self):
         for output_3d_t4dataset_name in self._t4dataset_name_to_merge.keys():
+            logger.info(f"Merge 2D annotation to {output_3d_t4dataset_name}")
             input_t4dataset_name = self._t4dataset_name_to_merge[output_3d_t4dataset_name]
             input_2d_annotation_dir = self._input_base / input_t4dataset_name / "annotation"
             if not input_2d_annotation_dir.exists():

--- a/perception_dataset/t4_dataset/t4_dataset_2d3d_merger.py
+++ b/perception_dataset/t4_dataset/t4_dataset_2d3d_merger.py
@@ -15,12 +15,10 @@ class T4dataset2D3DMerger(AbstractConverter):
         self,
         input_base: str,
         output_base: str,
-        overwrite_mode: bool,
         dataset_corresponding: Dict[str, int],
     ):
         self._input_base = Path(input_base)
         self._output_base = Path(output_base)
-        self._overwrite_mode = overwrite_mode
         self._t4dataset_name_to_merge: Dict[str, str] = dataset_corresponding
 
     def convert(self):
@@ -28,17 +26,6 @@ class T4dataset2D3DMerger(AbstractConverter):
             input_t4dataset_name = self._t4dataset_name_to_merge[output_3d_t4dataset_name]
             input_2d_annotation_dir = self._input_base / input_t4dataset_name / "annotation"
             output_3d_annotation_dir = self._output_base / output_3d_t4dataset_name / "annotation"
-
-            input_t4_dataset_2d = NuImages(
-                version="annotation",
-                dataroot=self._input_base / input_t4dataset_name,
-                verbose=False,
-            )
-            output_t4_dataset_3d = NuScenes(
-                version="annotation",
-                dataroot=self._output_base / output_3d_t4dataset_name,
-                verbose=False,
-            )
 
             out_attribute, attribute_in_out_token_map = self._merge_json_files(
                 input_2d_annotation_dir, output_3d_annotation_dir, "attribute.json"

--- a/perception_dataset/t4_dataset/t4_dataset_2d3d_merger.py
+++ b/perception_dataset/t4_dataset/t4_dataset_2d3d_merger.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 from nuimages import NuImages
 from nuscenes import NuScenes
+
 from perception_dataset.abstract_converter import AbstractConverter
 from perception_dataset.utils.logger import configure_logger
 
@@ -26,7 +27,9 @@ class T4dataset2D3DMerger(AbstractConverter):
             input_t4dataset_name = self._t4dataset_name_to_merge[output_3d_t4dataset_name]
             input_2d_annotation_dir = self._input_base / input_t4dataset_name / "annotation"
             if not input_2d_annotation_dir.exists():
-                input_2d_annotation_dir = self._input_base / input_t4dataset_name / "t4_dataset/annotation"
+                input_2d_annotation_dir = (
+                    self._input_base / input_t4dataset_name / "t4_dataset/annotation"
+                )
             if not input_2d_annotation_dir.exists():
                 logger.warning(f"input_dir {input_2d_annotation_dir} not exists.")
                 continue
@@ -50,7 +53,10 @@ class T4dataset2D3DMerger(AbstractConverter):
             )
 
             out_object_ann = self._update_object_ann(
-                input_2d_annotation_dir, attribute_in_out_token_map, category_in_out_token_map, instance_in_out_token_map
+                input_2d_annotation_dir,
+                attribute_in_out_token_map,
+                category_in_out_token_map,
+                instance_in_out_token_map,
             )
             out_surface_ann = self._update_surface_ann(
                 input_2d_annotation_dir, category_in_out_token_map
@@ -68,7 +74,6 @@ class T4dataset2D3DMerger(AbstractConverter):
             with open(output_3d_annotation_dir / "surface_ann.json", "w") as f:
                 json.dump(out_surface_ann, f, indent=4)
 
-
     def _merge_json_files(self, input_dir, output_dir, filename):
         """
         Merge the input json file to the output json file
@@ -84,7 +89,7 @@ class T4dataset2D3DMerger(AbstractConverter):
             in_data: list[dict[str, str]] = json.load(f)
         with open(output_dir / filename) as f:
             out_data: list[dict[str, str]] = json.load(f)
-        
+
         in_out_token_map = {}
         for in_d in in_data:
             for out_d in out_data:
@@ -96,12 +101,18 @@ class T4dataset2D3DMerger(AbstractConverter):
                     if in_d["token"] == out_d["token"]:
                         in_out_token_map[in_d["token"]] = out_d["token"]
                         break
-                
+
         out_data += [d for d in in_data if d["token"] not in in_out_token_map.keys()]
 
         return out_data, in_out_token_map
-        
-    def _update_object_ann(self, input_2d_annotation_dir, attribute_in_out_token_map, category_in_out_token_map, instance_in_out_token_map):
+
+    def _update_object_ann(
+        self,
+        input_2d_annotation_dir,
+        attribute_in_out_token_map,
+        category_in_out_token_map,
+        instance_in_out_token_map,
+    ):
         """
         Update the attribute token, category token, and instance token in object annotation json file
         Args:
@@ -109,10 +120,12 @@ class T4dataset2D3DMerger(AbstractConverter):
             attribute_in_out_token_map: mapping of input attribute token to output attribute token
             category_in_out_token_map: mapping of input category token to output category token
             instance_in_out_token_map: mapping of input instance token to output instance token
+        Return:
+            object_ann: list of updated object annotation data
         """
         with open(input_2d_annotation_dir / "object_ann.json") as f:
             object_ann: list[dict[str, str]] = json.load(f)
-        
+
         for obj in object_ann:
             for attribute_token in obj["attribute_tokens"]:
                 if attribute_token in attribute_in_out_token_map.keys():
@@ -122,19 +135,22 @@ class T4dataset2D3DMerger(AbstractConverter):
                 obj["category_token"] = category_in_out_token_map[obj["category_token"]]
             if obj["instance_token"] in instance_in_out_token_map.keys():
                 obj["instance_token"] = instance_in_out_token_map[obj["instance_token"]]
-        
+
         return object_ann
-    
+
     def _update_surface_ann(self, input_2d_annotation_dir, category_in_out_token_map):
         """
         Update the category token in surface annotation json file
         Args:
             input_2d_annotation_dir: input directory
             category_in_out_token_map: mapping of input category token to output category token
+        Return:
+            surface_ann: list of updated surface annotation data
         """
         with open(input_2d_annotation_dir / "surface_ann.json") as f:
             surface_ann: list[dict[str, str]] = json.load(f)
-        
+
         for surface in surface_ann:
             if surface["category_token"] in category_in_out_token_map.keys():
                 surface["category_token"] = category_in_out_token_map[surface["category_token"]]
+        return surface_ann

--- a/perception_dataset/t4_dataset/t4_dataset_2d3d_merger.py
+++ b/perception_dataset/t4_dataset/t4_dataset_2d3d_merger.py
@@ -25,7 +25,16 @@ class T4dataset2D3DMerger(AbstractConverter):
         for output_3d_t4dataset_name in self._t4dataset_name_to_merge.keys():
             input_t4dataset_name = self._t4dataset_name_to_merge[output_3d_t4dataset_name]
             input_2d_annotation_dir = self._input_base / input_t4dataset_name / "annotation"
+            if not input_2d_annotation_dir.exists():
+                input_2d_annotation_dir = self._input_base / input_t4dataset_name / "t4_dataset/annotation"
+            if not input_2d_annotation_dir.exists():
+                logger.warning(f"input_dir {input_2d_annotation_dir} not exists.")
+                continue
+
             output_3d_annotation_dir = self._output_base / output_3d_t4dataset_name / "annotation"
+            if not output_3d_annotation_dir.exists():
+                logger.warning(f"output_dir {output_3d_annotation_dir} not exists.")
+                continue
 
             out_attribute, attribute_in_out_token_map = self._merge_json_files(
                 input_2d_annotation_dir, output_3d_annotation_dir, "attribute.json"
@@ -77,8 +86,6 @@ class T4dataset2D3DMerger(AbstractConverter):
             out_data: list[dict[str, str]] = json.load(f)
         
         in_out_token_map = {}
-        print(f"input data: {len(in_data)}")
-        print(f"output data: {len(out_data)}")
         for in_d in in_data:
             for out_d in out_data:
                 if "name" in in_d.keys():
@@ -91,8 +98,6 @@ class T4dataset2D3DMerger(AbstractConverter):
                         break
                 
         out_data += [d for d in in_data if d["token"] not in in_out_token_map.keys()]
-        print(f"output data: {len(out_data)}")
-        print([d for d in in_data if d["token"] not in in_out_token_map.keys()])
 
         return out_data, in_out_token_map
         

--- a/perception_dataset/t4_dataset/t4_dataset_2d3d_merger.py
+++ b/perception_dataset/t4_dataset/t4_dataset_2d3d_merger.py
@@ -69,6 +69,8 @@ class T4dataset2D3DMerger(AbstractConverter):
                 json.dump(out_visibility, f, indent=4)
             with open(output_3d_annotation_dir / "object_ann.json", "w") as f:
                 json.dump(out_object_ann, f, indent=4)
+            with open(output_3d_annotation_dir / "surface_ann.json", "w") as f:
+                json.dump(out_surface_ann, f, indent=4)
 
 
     def _merge_json_files(self, input_dir, output_dir, filename):

--- a/perception_dataset/t4_dataset/t4_dataset_2d3d_merger.py
+++ b/perception_dataset/t4_dataset/t4_dataset_2d3d_merger.py
@@ -2,9 +2,6 @@ import json
 from pathlib import Path
 from typing import Dict
 
-from nuimages import NuImages
-from nuscenes import NuScenes
-
 from perception_dataset.abstract_converter import AbstractConverter
 from perception_dataset.utils.logger import configure_logger
 

--- a/perception_dataset/t4_dataset/t4_dataset_2d3d_merger.py
+++ b/perception_dataset/t4_dataset/t4_dataset_2d3d_merger.py
@@ -1,0 +1,146 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+from nuimages import NuImages
+from nuscenes import NuScenes
+from perception_dataset.abstract_converter import AbstractConverter
+from perception_dataset.utils.logger import configure_logger
+
+logger = configure_logger(modname=__name__)
+
+
+class T4dataset2D3DMerger(AbstractConverter):
+    def __init__(
+        self,
+        input_base: str,
+        output_base: str,
+        overwrite_mode: bool,
+        dataset_corresponding: Dict[str, int],
+    ):
+        self._input_base = Path(input_base)
+        self._output_base = Path(output_base)
+        self._overwrite_mode = overwrite_mode
+        self._t4dataset_name_to_merge: Dict[str, str] = dataset_corresponding
+
+    def convert(self):
+        for output_3d_t4dataset_name in self._t4dataset_name_to_merge.keys():
+            input_t4dataset_name = self._t4dataset_name_to_merge[output_3d_t4dataset_name]
+            input_2d_annotation_dir = self._input_base / input_t4dataset_name / "annotation"
+            output_3d_annotation_dir = self._output_base / output_3d_t4dataset_name / "annotation"
+
+            input_t4_dataset_2d = NuImages(
+                version="annotation",
+                dataroot=self._input_base / input_t4dataset_name,
+                verbose=False,
+            )
+            output_t4_dataset_3d = NuScenes(
+                version="annotation",
+                dataroot=self._output_base / output_3d_t4dataset_name,
+                verbose=False,
+            )
+
+            out_attribute, attribute_in_out_token_map = self._merge_json_files(
+                input_2d_annotation_dir, output_3d_annotation_dir, "attribute.json"
+            )
+            out_category, category_in_out_token_map = self._merge_json_files(
+                input_2d_annotation_dir, output_3d_annotation_dir, "category.json"
+            )
+            out_instance, instance_in_out_token_map = self._merge_json_files(
+                input_2d_annotation_dir, output_3d_annotation_dir, "instance.json"
+            )
+            out_visibility, visibility_in_out_token_map = self._merge_json_files(
+                input_2d_annotation_dir, output_3d_annotation_dir, "visibility.json"
+            )
+
+            out_object_ann = self._update_object_ann(
+                input_2d_annotation_dir, attribute_in_out_token_map, category_in_out_token_map, instance_in_out_token_map
+            )
+            out_surface_ann = self._update_surface_ann(
+                input_2d_annotation_dir, category_in_out_token_map
+            )
+            with open(output_3d_annotation_dir / "attribute.json", "w") as f:
+                json.dump(out_attribute, f, indent=4)
+            with open(output_3d_annotation_dir / "category.json", "w") as f:
+                json.dump(out_category, f, indent=4)
+            with open(output_3d_annotation_dir / "instance.json", "w") as f:
+                json.dump(out_instance, f, indent=4)
+            with open(output_3d_annotation_dir / "visibility.json", "w") as f:
+                json.dump(out_visibility, f, indent=4)
+            with open(output_3d_annotation_dir / "object_ann.json", "w") as f:
+                json.dump(out_object_ann, f, indent=4)
+
+
+    def _merge_json_files(self, input_dir, output_dir, filename):
+        """
+        Merge the input json file to the output json file
+        Args:
+            input_dir: input directory
+            output_dir: output directory
+            filename: json file name
+        return:
+            out_json_data: list of output json data
+            in_out_token_map: mapping of input token to output token for the same name data
+        """
+        with open(input_dir / filename) as f:
+            in_data: list[dict[str, str]] = json.load(f)
+        with open(output_dir / filename) as f:
+            out_data: list[dict[str, str]] = json.load(f)
+        
+        in_out_token_map = {}
+        print(f"input data: {len(in_data)}")
+        print(f"output data: {len(out_data)}")
+        for in_d in in_data:
+            for out_d in out_data:
+                if "name" in in_d.keys():
+                    if in_d["name"] == out_d["name"]:
+                        in_out_token_map[in_d["token"]] = out_d["token"]
+                        break
+                elif "token" in in_d.keys():
+                    if in_d["token"] == out_d["token"]:
+                        in_out_token_map[in_d["token"]] = out_d["token"]
+                        break
+                
+        out_data += [d for d in in_data if d["token"] not in in_out_token_map.keys()]
+        print(f"output data: {len(out_data)}")
+        print([d for d in in_data if d["token"] not in in_out_token_map.keys()])
+
+        return out_data, in_out_token_map
+        
+    def _update_object_ann(self, input_2d_annotation_dir, attribute_in_out_token_map, category_in_out_token_map, instance_in_out_token_map):
+        """
+        Update the attribute token, category token, and instance token in object annotation json file
+        Args:
+            input_2d_annotation_dir: input directory
+            attribute_in_out_token_map: mapping of input attribute token to output attribute token
+            category_in_out_token_map: mapping of input category token to output category token
+            instance_in_out_token_map: mapping of input instance token to output instance token
+        """
+        with open(input_2d_annotation_dir / "object_ann.json") as f:
+            object_ann: list[dict[str, str]] = json.load(f)
+        
+        for obj in object_ann:
+            for attribute_token in obj["attribute_tokens"]:
+                if attribute_token in attribute_in_out_token_map.keys():
+                    obj["attribute_tokens"].remove(attribute_token)
+                    obj["attribute_tokens"].append(attribute_in_out_token_map[attribute_token])
+            if obj["category_token"] in category_in_out_token_map.keys():
+                obj["category_token"] = category_in_out_token_map[obj["category_token"]]
+            if obj["instance_token"] in instance_in_out_token_map.keys():
+                obj["instance_token"] = instance_in_out_token_map[obj["instance_token"]]
+        
+        return object_ann
+    
+    def _update_surface_ann(self, input_2d_annotation_dir, category_in_out_token_map):
+        """
+        Update the category token in surface annotation json file
+        Args:
+            input_2d_annotation_dir: input directory
+            category_in_out_token_map: mapping of input category token to output category token
+        """
+        with open(input_2d_annotation_dir / "surface_ann.json") as f:
+            surface_ann: list[dict[str, str]] = json.load(f)
+        
+        for surface in surface_ann:
+            if surface["category_token"] in category_in_out_token_map.keys():
+                surface["category_token"] = category_in_out_token_map[surface["category_token"]]


### PR DESCRIPTION
## Description
This Pull Request introduces functionality to merge datasets from T4 containing annotations for both 2D camera images and 3D LiDAR point clouds.

The purpose of this feature is to combine annotations from different sensor modalities, specifically 2D camera images and 3D LiDAR point clouds, thereby creating comprehensive datasets suitable for tasks involving multi-sensor fusion and perception.

- Implemented a new merge functionality capable of appropriately integrating annotations from 2D camera images and 3D LiDAR point clouds to produce a unified dataset.
- Added comprehensive documentation detailing the usage of the new feature and providing insights into API specifics.
Included unit tests to ensure the correctness and robustness of the new functionality.

## How to test
Please review that the 2D bboxes are correctly assigned and 3D cuboids are .
Check the dataset visualization videos: https://drive.google.com/drive/folders/1zNbkXMpr3qBLR7VC32IUPD1dxk_9dsSL

### test data
test data:

- 2D only T4 dataset: https://drive.google.com/drive/u/0/folders/1KcEw5M_j-LmAhyRRXHDE65ttlWp7bID1
- 3D only T4 dataset: https://drive.google.com/drive/folders/1Fh1X5oBN-7ej5vdANxaPo-F-uRS8_1uA


### test command

<!-- Describe how to test this PR. -->

```bash
python -m perception_dataset.convert --config config/merge_2d_t4dataset_to_3d.yaml
```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
