### PR TITLE
feat: add backward compatibility for autoware_auto_msgs and autoware_msgs

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -72,7 +72,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
         with:
           rosdistro: ${{ matrix.rosdistro }}
-          target-packages: autoware_auto_perception_msgs tier4_perception_msgs
+          target-packages: autoware_auto_perception_msgs autoware_perception_msgs tier4_perception_msgs
           build-depends-repos: build_depends.repos
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ git clone git@github.com:tier4/tier4_perception_dataset.git perception_dataset
 cd perception_dataset
 ```
 
-install and build ros dependencies (this step must be outside of poetry virtualenv)
+Install and build ros dependencies (this step must be outside of poetry virtualenv):
 
 ```bash
 source /opt/ros/${ROS_DISTRO}/setup.sh
@@ -24,7 +24,9 @@ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --package
 source ./install/setup.bash
 ```
 
-install python dependencies
+As of 2024/06/10, the repository supports both `autoware_msgs` and `autoware_auto_msgs`. The above command will install both messages. If you want to install only one of them, please remove the unnecessary message from `build_depends.repos`.
+
+Install python dependencies:
 
 ```bash
 pip3 install poetry

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --package
 source ./install/setup.bash
 ```
 
-As of 2024/06/10, the repository supports both `autoware_msgs` and `autoware_auto_msgs`. The above command will install both messages. If you want to install only one of them, please remove the unnecessary message from `build_depends.repos`.
+As of 2024/06/10, the repository requires both `autoware_msgs` and `autoware_auto_msgs`. The above command will install both messages.
+If you already have either of them, you can remove the unnecessary one from `build_depends.repos`.
 
 Install python dependencies:
 

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -1,8 +1,4 @@
 repositories:
-  autoware_auto_msgs:
-    type: git
-    url: https://github.com/tier4/autoware_auto_msgs.git
-    version: tier4/main
   tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
@@ -11,3 +7,9 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
     version: main
+
+  # This repository should eventually be removed. See https://github.com/orgs/autowarefoundation/discussions/3862
+  autoware_auto_msgs:
+    type: git
+    url: https://github.com/tier4/autoware_auto_msgs.git
+    version: tier4/main

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -9,5 +9,5 @@ repositories:
     version: tier4/universe
   autoware_msgs:
     type: git
-    url: https://github.com/autowarefoundation/autoware_msgs.git
+    url: https://github.com/tier4/autoware_msgs.git
     version: main

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -9,5 +9,5 @@ repositories:
     version: tier4/universe
   autoware_msgs:
     type: git
-    url: https://github.com/tier4/autoware_msgs.git
+    url: https://github.com/autowarefoundation/autoware_msgs.git
     version: main

--- a/perception_dataset/rosbag2/autoware_msgs.py
+++ b/perception_dataset/rosbag2/autoware_msgs.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Optional, Union
 import uuid
 
+from autoware_auto_perception_msgs.msg import (
+    ObjectClassification as AutowareAutoObjectClassification,
+)
 from autoware_auto_perception_msgs.msg import DetectedObjects as AutowareAutoDetectedObjects
-from autoware_auto_perception_msgs.msg import ObjectClassification as AutowareAutoObjectClassification
 from autoware_auto_perception_msgs.msg import TrackedObjects as AutowareAutoTrackedObjects
-
 from autoware_perception_msgs.msg import DetectedObjects as AutowareDetectedObjects
 from autoware_perception_msgs.msg import ObjectClassification as AutowareObjectClassification
 from autoware_perception_msgs.msg import TrackedObjects as AutowareTrackedObjects
-
 from tier4_perception_msgs.msg import (
     TrafficLight,
     TrafficLightArray,
@@ -104,6 +104,7 @@ def object_classification_to_category_name(object_classification) -> str:
 
     return cls_to_cat.get(object_classification, "unknown")
 
+
 def parse_autoware_perception_objects(msg) -> List[Dict[str, Any]]:
     """
     Args:
@@ -113,10 +114,18 @@ def parse_autoware_perception_objects(msg) -> List[Dict[str, Any]]:
         List[Dict[str, Any]]: dict format
     """
     assert isinstance(
-        msg, (AutowareDetectedObjects, AutowareTrackedObjects, AutowareAutoDetectedObjects, AutowareAutoTrackedObjects)
+        msg,
+        (
+            AutowareDetectedObjects,
+            AutowareTrackedObjects,
+            AutowareAutoDetectedObjects,
+            AutowareAutoTrackedObjects,
+        ),
     ), f"Invalid object message type: {type(msg)}"
 
-    def get_category_name(classification: List[Union[AutowareAutoObjectClassification, AutowareObjectClassification]]) -> str:
+    def get_category_name(
+        classification: List[Union[AutowareAutoObjectClassification, AutowareObjectClassification]]
+    ) -> str:
         max_score: float = -1.0
         out_class_name: str = "unknown"
         for obj_cls in classification:
@@ -127,10 +136,17 @@ def parse_autoware_perception_objects(msg) -> List[Dict[str, Any]]:
 
     scene_annotation_list: List[Dict[str, Any]] = []
     for obj in msg.objects:
-        obj: Union[AutowareAutoDetectedObjects, AutowareAutoTrackedObjects, AutowareDetectedObjects, AutowareTrackedObjects]
+        obj: Union[
+            AutowareAutoDetectedObjects,
+            AutowareAutoTrackedObjects,
+            AutowareDetectedObjects,
+            AutowareTrackedObjects,
+        ]
         pose = obj.kinematics.pose_with_covariance.pose
 
-        if isinstance(obj, AutowareAutoDetectedObjects) or isinstance(obj, AutowareDetectedObjects):
+        if isinstance(obj, AutowareAutoDetectedObjects) or isinstance(
+            obj, AutowareDetectedObjects
+        ):
             obj_uuid = uuid.uuid4()  # random uuid
             velocity: Dict[str, float] = {
                 "x": obj.kinematics.twist_with_covariance.twist.linear.x,
@@ -138,7 +154,9 @@ def parse_autoware_perception_objects(msg) -> List[Dict[str, Any]]:
                 "z": obj.kinematics.twist_with_covariance.twist.linear.z,
             }
             acceleration: Optional[Dict[str, float]] = None
-        elif isinstance(obj, AutowareAutoTrackedObjects) or isinstance(obj, AutowareTrackedObjects):
+        elif isinstance(obj, AutowareAutoTrackedObjects) or isinstance(
+            obj, AutowareTrackedObjects
+        ):
             obj_uuid = uuid.UUID(bytes=obj.object_id.uuid.tobytes())
             velocity: Dict[str, float] = {
                 "x": obj.kinematics.twist_with_covariance.twist.linear.x,

--- a/perception_dataset/rosbag2/autoware_msgs.py
+++ b/perception_dataset/rosbag2/autoware_msgs.py
@@ -105,7 +105,7 @@ def object_classification_to_category_name(object_classification) -> str:
     return cls_to_cat.get(object_classification, "unknown")
 
 
-def parse_autoware_perception_objects(msg) -> List[Dict[str, Any]]:
+def parse_perception_objects(msg) -> List[Dict[str, Any]]:
     """
     Args:
         msg: autoware detection msg (.core/.universe)

--- a/perception_dataset/rosbag2/autoware_msgs.py
+++ b/perception_dataset/rosbag2/autoware_msgs.py
@@ -4,15 +4,17 @@ import uuid
 from autoware_auto_perception_msgs.msg import (
     ObjectClassification as AutowareAutoObjectClassification,
 )
-from autoware_auto_perception_msgs.msg import DetectedObjects as AutowareAutoDetectedObject
 from autoware_auto_perception_msgs.msg import DetectedObjects as AutowareAutoDetectedObjects
-from autoware_auto_perception_msgs.msg import TrackedObjects as AutowareAutoTrackedObject
 from autoware_auto_perception_msgs.msg import TrackedObjects as AutowareAutoTrackedObjects
-from autoware_perception_msgs.msg import DetectedObjects as AutowareDetectedObject
-from autoware_perception_msgs.msg import DetectedObjects as AutowareDetectedObjects
+from autoware_auto_perception_msgs.msg import DetectedObject as AutowareAutoDetectedObject
+from autoware_auto_perception_msgs.msg import TrackedObject as AutowareAutoTrackedObject
+
 from autoware_perception_msgs.msg import ObjectClassification as AutowareObjectClassification
-from autoware_perception_msgs.msg import TrackedObjects as AutowareTrackedObject
+from autoware_perception_msgs.msg import DetectedObjects as AutowareDetectedObjects
 from autoware_perception_msgs.msg import TrackedObjects as AutowareTrackedObjects
+from autoware_perception_msgs.msg import DetectedObject as AutowareDetectedObject
+from autoware_perception_msgs.msg import TrackedObject as AutowareTrackedObject
+
 from tier4_perception_msgs.msg import (
     TrafficLight,
     TrafficLightArray,
@@ -148,7 +150,10 @@ def parse_perception_objects(msg) -> List[Dict[str, Any]]:
         ]
         pose = obj.kinematics.pose_with_covariance.pose
 
-        if isinstance(obj, AutowareAutoDetectedObject) or isinstance(obj, AutowareDetectedObject):
+        print(AutowareAutoDetectedObject, AutowareAutoTrackedObject, AutowareDetectedObject, AutowareTrackedObject)
+        if isinstance(obj, AutowareAutoDetectedObject) or isinstance(
+            obj, AutowareDetectedObject
+        ):
             obj_uuid = uuid.uuid4()  # random uuid
             velocity: Dict[str, float] = {
                 "x": obj.kinematics.twist_with_covariance.twist.linear.x,

--- a/perception_dataset/rosbag2/autoware_msgs.py
+++ b/perception_dataset/rosbag2/autoware_msgs.py
@@ -148,12 +148,6 @@ def parse_perception_objects(msg) -> List[Dict[str, Any]]:
         ]
         pose = obj.kinematics.pose_with_covariance.pose
 
-        print(
-            AutowareAutoDetectedObject,
-            AutowareAutoTrackedObject,
-            AutowareDetectedObject,
-            AutowareTrackedObject,
-        )
         if isinstance(obj, (AutowareAutoDetectedObject, AutowareDetectedObject)):
             obj_uuid = uuid.uuid4()  # random uuid
             velocity: Dict[str, float] = {

--- a/perception_dataset/rosbag2/autoware_msgs.py
+++ b/perception_dataset/rosbag2/autoware_msgs.py
@@ -4,17 +4,15 @@ import uuid
 from autoware_auto_perception_msgs.msg import (
     ObjectClassification as AutowareAutoObjectClassification,
 )
-from autoware_auto_perception_msgs.msg import DetectedObjects as AutowareAutoDetectedObjects
-from autoware_auto_perception_msgs.msg import TrackedObjects as AutowareAutoTrackedObjects
 from autoware_auto_perception_msgs.msg import DetectedObject as AutowareAutoDetectedObject
+from autoware_auto_perception_msgs.msg import DetectedObjects as AutowareAutoDetectedObjects
 from autoware_auto_perception_msgs.msg import TrackedObject as AutowareAutoTrackedObject
-
-from autoware_perception_msgs.msg import ObjectClassification as AutowareObjectClassification
-from autoware_perception_msgs.msg import DetectedObjects as AutowareDetectedObjects
-from autoware_perception_msgs.msg import TrackedObjects as AutowareTrackedObjects
+from autoware_auto_perception_msgs.msg import TrackedObjects as AutowareAutoTrackedObjects
 from autoware_perception_msgs.msg import DetectedObject as AutowareDetectedObject
+from autoware_perception_msgs.msg import DetectedObjects as AutowareDetectedObjects
+from autoware_perception_msgs.msg import ObjectClassification as AutowareObjectClassification
 from autoware_perception_msgs.msg import TrackedObject as AutowareTrackedObject
-
+from autoware_perception_msgs.msg import TrackedObjects as AutowareTrackedObjects
 from tier4_perception_msgs.msg import (
     TrafficLight,
     TrafficLightArray,
@@ -150,10 +148,13 @@ def parse_perception_objects(msg) -> List[Dict[str, Any]]:
         ]
         pose = obj.kinematics.pose_with_covariance.pose
 
-        print(AutowareAutoDetectedObject, AutowareAutoTrackedObject, AutowareDetectedObject, AutowareTrackedObject)
-        if isinstance(obj, AutowareAutoDetectedObject) or isinstance(
-            obj, AutowareDetectedObject
-        ):
+        print(
+            AutowareAutoDetectedObject,
+            AutowareAutoTrackedObject,
+            AutowareDetectedObject,
+            AutowareTrackedObject,
+        )
+        if isinstance(obj, AutowareAutoDetectedObject) or isinstance(obj, AutowareDetectedObject):
             obj_uuid = uuid.uuid4()  # random uuid
             velocity: Dict[str, float] = {
                 "x": obj.kinematics.twist_with_covariance.twist.linear.x,

--- a/perception_dataset/rosbag2/autoware_msgs.py
+++ b/perception_dataset/rosbag2/autoware_msgs.py
@@ -6,9 +6,15 @@ from autoware_auto_perception_msgs.msg import (
 )
 from autoware_auto_perception_msgs.msg import DetectedObjects as AutowareAutoDetectedObjects
 from autoware_auto_perception_msgs.msg import TrackedObjects as AutowareAutoTrackedObjects
-from autoware_perception_msgs.msg import DetectedObjects as AutowareDetectedObjects
+from autoware_auto_perception_msgs.msg import DetectedObjects as AutowareAutoDetectedObject
+from autoware_auto_perception_msgs.msg import TrackedObjects as AutowareAutoTrackedObject
+
 from autoware_perception_msgs.msg import ObjectClassification as AutowareObjectClassification
+from autoware_perception_msgs.msg import DetectedObjects as AutowareDetectedObjects
 from autoware_perception_msgs.msg import TrackedObjects as AutowareTrackedObjects
+from autoware_perception_msgs.msg import DetectedObjects as AutowareDetectedObject
+from autoware_perception_msgs.msg import TrackedObjects as AutowareTrackedObject
+
 from tier4_perception_msgs.msg import (
     TrafficLight,
     TrafficLightArray,
@@ -137,15 +143,15 @@ def parse_perception_objects(msg) -> List[Dict[str, Any]]:
     scene_annotation_list: List[Dict[str, Any]] = []
     for obj in msg.objects:
         obj: Union[
-            AutowareAutoDetectedObjects,
-            AutowareAutoTrackedObjects,
-            AutowareDetectedObjects,
-            AutowareTrackedObjects,
+            AutowareAutoDetectedObject,
+            AutowareAutoTrackedObject,
+            AutowareDetectedObject,
+            AutowareTrackedObject,
         ]
         pose = obj.kinematics.pose_with_covariance.pose
 
-        if isinstance(obj, AutowareAutoDetectedObjects) or isinstance(
-            obj, AutowareDetectedObjects
+        if isinstance(obj, AutowareAutoDetectedObject) or isinstance(
+            obj, AutowareDetectedObject
         ):
             obj_uuid = uuid.uuid4()  # random uuid
             velocity: Dict[str, float] = {
@@ -154,8 +160,8 @@ def parse_perception_objects(msg) -> List[Dict[str, Any]]:
                 "z": obj.kinematics.twist_with_covariance.twist.linear.z,
             }
             acceleration: Optional[Dict[str, float]] = None
-        elif isinstance(obj, AutowareAutoTrackedObjects) or isinstance(
-            obj, AutowareTrackedObjects
+        elif isinstance(obj, AutowareAutoTrackedObject) or isinstance(
+            obj, AutowareTrackedObject
         ):
             obj_uuid = uuid.UUID(bytes=obj.object_id.uuid.tobytes())
             velocity: Dict[str, float] = {

--- a/perception_dataset/rosbag2/autoware_msgs.py
+++ b/perception_dataset/rosbag2/autoware_msgs.py
@@ -154,7 +154,7 @@ def parse_perception_objects(msg) -> List[Dict[str, Any]]:
             AutowareDetectedObject,
             AutowareTrackedObject,
         )
-        if isinstance(obj, AutowareAutoDetectedObject) or isinstance(obj, AutowareDetectedObject):
+        if isinstance(obj, (AutowareAutoDetectedObject, AutowareDetectedObject)):
             obj_uuid = uuid.uuid4()  # random uuid
             velocity: Dict[str, float] = {
                 "x": obj.kinematics.twist_with_covariance.twist.linear.x,
@@ -162,7 +162,7 @@ def parse_perception_objects(msg) -> List[Dict[str, Any]]:
                 "z": obj.kinematics.twist_with_covariance.twist.linear.z,
             }
             acceleration: Optional[Dict[str, float]] = None
-        elif isinstance(obj, AutowareAutoTrackedObject) or isinstance(obj, AutowareTrackedObject):
+        elif isinstance(obj, (AutowareAutoTrackedObject, AutowareTrackedObject)):
             obj_uuid = uuid.UUID(bytes=obj.object_id.uuid.tobytes())
             velocity: Dict[str, float] = {
                 "x": obj.kinematics.twist_with_covariance.twist.linear.x,

--- a/perception_dataset/rosbag2/autoware_msgs.py
+++ b/perception_dataset/rosbag2/autoware_msgs.py
@@ -4,17 +4,15 @@ import uuid
 from autoware_auto_perception_msgs.msg import (
     ObjectClassification as AutowareAutoObjectClassification,
 )
-from autoware_auto_perception_msgs.msg import DetectedObjects as AutowareAutoDetectedObjects
-from autoware_auto_perception_msgs.msg import TrackedObjects as AutowareAutoTrackedObjects
 from autoware_auto_perception_msgs.msg import DetectedObjects as AutowareAutoDetectedObject
+from autoware_auto_perception_msgs.msg import DetectedObjects as AutowareAutoDetectedObjects
 from autoware_auto_perception_msgs.msg import TrackedObjects as AutowareAutoTrackedObject
-
-from autoware_perception_msgs.msg import ObjectClassification as AutowareObjectClassification
-from autoware_perception_msgs.msg import DetectedObjects as AutowareDetectedObjects
-from autoware_perception_msgs.msg import TrackedObjects as AutowareTrackedObjects
+from autoware_auto_perception_msgs.msg import TrackedObjects as AutowareAutoTrackedObjects
 from autoware_perception_msgs.msg import DetectedObjects as AutowareDetectedObject
+from autoware_perception_msgs.msg import DetectedObjects as AutowareDetectedObjects
+from autoware_perception_msgs.msg import ObjectClassification as AutowareObjectClassification
 from autoware_perception_msgs.msg import TrackedObjects as AutowareTrackedObject
-
+from autoware_perception_msgs.msg import TrackedObjects as AutowareTrackedObjects
 from tier4_perception_msgs.msg import (
     TrafficLight,
     TrafficLightArray,
@@ -150,9 +148,7 @@ def parse_perception_objects(msg) -> List[Dict[str, Any]]:
         ]
         pose = obj.kinematics.pose_with_covariance.pose
 
-        if isinstance(obj, AutowareAutoDetectedObject) or isinstance(
-            obj, AutowareDetectedObject
-        ):
+        if isinstance(obj, AutowareAutoDetectedObject) or isinstance(obj, AutowareDetectedObject):
             obj_uuid = uuid.uuid4()  # random uuid
             velocity: Dict[str, float] = {
                 "x": obj.kinematics.twist_with_covariance.twist.linear.x,
@@ -160,9 +156,7 @@ def parse_perception_objects(msg) -> List[Dict[str, Any]]:
                 "z": obj.kinematics.twist_with_covariance.twist.linear.z,
             }
             acceleration: Optional[Dict[str, float]] = None
-        elif isinstance(obj, AutowareAutoTrackedObject) or isinstance(
-            obj, AutowareTrackedObject
-        ):
+        elif isinstance(obj, AutowareAutoTrackedObject) or isinstance(obj, AutowareTrackedObject):
             obj_uuid = uuid.UUID(bytes=obj.object_id.uuid.tobytes())
             velocity: Dict[str, float] = {
                 "x": obj.kinematics.twist_with_covariance.twist.linear.x,

--- a/perception_dataset/rosbag2/autoware_msgs.py
+++ b/perception_dataset/rosbag2/autoware_msgs.py
@@ -1,13 +1,14 @@
 from typing import Any, Dict, List, Optional, Union
 import uuid
 
-from autoware_auto_perception_msgs.msg import (
-    DetectedObject,
-    DetectedObjects,
-    ObjectClassification,
-    TrackedObject,
-    TrackedObjects,
-)
+from autoware_auto_perception_msgs.msg import DetectedObjects as AutowareAutoDetectedObjects
+from autoware_auto_perception_msgs.msg import ObjectClassification as AutowareAutoObjectClassification
+from autoware_auto_perception_msgs.msg import TrackedObjects as AutowareAutoTrackedObjects
+
+from autoware_perception_msgs.msg import DetectedObjects as AutowareDetectedObjects
+from autoware_perception_msgs.msg import ObjectClassification as AutowareObjectClassification
+from autoware_perception_msgs.msg import TrackedObjects as AutowareTrackedObjects
+
 from tier4_perception_msgs.msg import (
     TrafficLight,
     TrafficLightArray,
@@ -103,22 +104,19 @@ def object_classification_to_category_name(object_classification) -> str:
 
     return cls_to_cat.get(object_classification, "unknown")
 
-
-def parse_perception_objects(msg) -> List[Dict[str, Any]]:
-    """https://github.com/tier4/autoware_auto_msgs/tree/tier4/main/autoware_auto_perception_msgs
-
-
+def parse_autoware_perception_objects(msg) -> List[Dict[str, Any]]:
+    """
     Args:
-        msg (autoware_auto_perception_msgs.msg.DetectedObjects): autoware detection msg (.core/.universe)
-
+        msg: autoware detection msg (.core/.universe)
+            valid type: AutowareDetectedObjects, AutowareTrackedObjects, AutowareAutoDetectedObjects, AutowareAutoTrackedObjects
     Returns:
         List[Dict[str, Any]]: dict format
     """
     assert isinstance(
-        msg, (DetectedObjects, TrackedObjects)
+        msg, (AutowareDetectedObjects, AutowareTrackedObjects, AutowareAutoDetectedObjects, AutowareAutoTrackedObjects)
     ), f"Invalid object message type: {type(msg)}"
 
-    def get_category_name(classification: List[ObjectClassification]) -> str:
+    def get_category_name(classification: List[Union[AutowareAutoObjectClassification, AutowareObjectClassification]]) -> str:
         max_score: float = -1.0
         out_class_name: str = "unknown"
         for obj_cls in classification:
@@ -129,10 +127,10 @@ def parse_perception_objects(msg) -> List[Dict[str, Any]]:
 
     scene_annotation_list: List[Dict[str, Any]] = []
     for obj in msg.objects:
-        obj: Union[DetectedObject, TrackedObject]
+        obj: Union[AutowareAutoDetectedObjects, AutowareAutoTrackedObjects, AutowareDetectedObjects, AutowareTrackedObjects]
         pose = obj.kinematics.pose_with_covariance.pose
 
-        if isinstance(obj, DetectedObject):
+        if isinstance(obj, AutowareAutoDetectedObjects) or isinstance(obj, AutowareDetectedObjects):
             obj_uuid = uuid.uuid4()  # random uuid
             velocity: Dict[str, float] = {
                 "x": obj.kinematics.twist_with_covariance.twist.linear.x,
@@ -140,7 +138,7 @@ def parse_perception_objects(msg) -> List[Dict[str, Any]]:
                 "z": obj.kinematics.twist_with_covariance.twist.linear.z,
             }
             acceleration: Optional[Dict[str, float]] = None
-        elif isinstance(obj, TrackedObject):
+        elif isinstance(obj, AutowareAutoTrackedObjects) or isinstance(obj, AutowareTrackedObjects):
             obj_uuid = uuid.UUID(bytes=obj.object_id.uuid.tobytes())
             velocity: Dict[str, float] = {
                 "x": obj.kinematics.twist_with_covariance.twist.linear.x,


### PR DESCRIPTION
## Description
Support both `autoware_auto_msgs` and `autoware_msgs`
<!-- Describe the changes -->

## How to review
See the pytest results in CI.

## Reference
None
<!-- Please write external reference if any. -->

## Notes for reviewer
None
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
