### PR TITLE
fix(non_annotated_t4_to_deepen): skip frame when some cameras do not exist

### DIFF
--- a/perception_dataset/deepen/non_annotated_t4_to_deepen_converter.py
+++ b/perception_dataset/deepen/non_annotated_t4_to_deepen_converter.py
@@ -108,6 +108,8 @@ class NonAnnotatedT4ToDeepenConverter(AbstractConverter):
                     if sensor["channel"] == camera_channel:
                         camera_token = sensor["token"]
                         break
+                logger.info(f"camera_token: {camera_channel} not found in frame {frame_index}, skipping this frame...")
+                return
 
             camera_path, _, cam_intrinsic = nusc.get_sample_data(camera_token)
             data_dict: Dict[str, Any] = self._get_data(nusc, camera_token)

--- a/perception_dataset/deepen/non_annotated_t4_to_deepen_converter.py
+++ b/perception_dataset/deepen/non_annotated_t4_to_deepen_converter.py
@@ -108,7 +108,9 @@ class NonAnnotatedT4ToDeepenConverter(AbstractConverter):
                     if sensor["channel"] == camera_channel:
                         camera_token = sensor["token"]
                         break
-                logger.info(f"camera_token: {camera_channel} not found in frame {frame_index}, skipping this frame...")
+                logger.info(
+                    f"camera_token: {camera_channel} not found in frame {frame_index}, skipping this frame..."
+                )
                 return
 
             camera_path, _, cam_intrinsic = nusc.get_sample_data(camera_token)

--- a/perception_dataset/deepen/non_annotated_t4_to_deepen_converter.py
+++ b/perception_dataset/deepen/non_annotated_t4_to_deepen_converter.py
@@ -108,8 +108,8 @@ class NonAnnotatedT4ToDeepenConverter(AbstractConverter):
                     if sensor["channel"] == camera_channel:
                         camera_token = sensor["token"]
                         break
-                logger.info(
-                    f"camera_token: {camera_channel} not found in frame {frame_index}, skipping this frame..."
+                logger.warning(
+                    f"camera: {camera_channel} not found in frame {frame_index}, skipping this frame..."
                 )
                 return
 


### PR DESCRIPTION
## Description
Following error occurs for some t4dataset. This PR is to address this issue.

```bash
jt08_odaiba_2024-04-16_gen2_withpcd_sliced/data/                                                                                                                                                                   
├── CAM_BACK_LEFT                                                                                                                                                                                                  
│   ├── ...
│   ├── 00270.jpg
│   └── 00271.jpg
├── CAM_BACK_RIGHT
│   ├── ...
│   └── 00270.jpg
├── CAM_FRONT
│   ├── ...
│   └── 00270.jpg
├── CAM_FRONT_LEFT
│   ├── ...
│   └── 00270.jpg
├── CAM_FRONT_RIGHT
│   ├── ...
│   └── 00270.jpg
└── LIDAR_CONCAT
...
```

## How to reproduce

1. Download [non annotated t4 dataset](https://drive.google.com/file/d/1_QSJysUMCFYagQqa3r7cXnf7XSHU6dNl/view?usp=sharing) and locate under `./data/non_annotated_t4_format`
2. Prepare `convert_non_annotated_t4_to_deepen_sample.yaml` (remove CAMERA_BACK)
3. Run `python3 -m perception_dataset.convert --config config/convert_non_annotated_t4_to_deepen_sample.yaml`

Which will result in 
```bash
"""
Traceback (most recent call last):
  File "/usr/lib/python3.10/concurrent/futures/process.py", line 246, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/home/minoda/ghq/github.com/tier4/tier4_perception_dataset/perception_dataset/deepen/non_annotated_t4_to_deepen_converter.py", line 112, in _convert_one_frame
    camera_path, _, cam_intrinsic = nusc.get_sample_data(camera_token)
UnboundLocalError: local variable 'camera_token' referenced before assignment
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/minoda/ghq/github.com/tier4/tier4_perception_dataset/perception_dataset/convert.py", line 368, in <module>
    main()
  File "/home/minoda/ghq/github.com/tier4/tier4_perception_dataset/perception_dataset/convert.py", line 87, in main
    converter.convert()
  File "/home/minoda/ghq/github.com/tier4/tier4_perception_dataset/perception_dataset/deepen/non_annotated_t4_to_deepen_converter.py", line 50, in convert
    self._convert_one_scene(
  File "/home/minoda/ghq/github.com/tier4/tier4_perception_dataset/perception_dataset/deepen/non_annotated_t4_to_deepen_converter.py", line 74, in _convert_one_scene
    [x.result() for x in future_list]
  File "/home/minoda/ghq/github.com/tier4/tier4_perception_dataset/perception_dataset/deepen/non_annotated_t4_to_deepen_converter.py", line 74, in <listcomp>
    [x.result() for x in future_list]
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
UnboundLocalError: local variable 'camera_token' referenced before assignment
```

<!-- Describe the changes -->

## How to review

<!-- Describe the review procedure -->

## How to test

- Please follow the above procedure and confirm that the error is addressed.
- Please verify that the above issue is OK to address in `non_annotated_t4_to_deepen` rather than in `rosbag_to_non_annotated_t4`

## Reference
None
<!-- Please write external reference if any. -->

## Notes for reviewer
None
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
