### PR TITLE
fix `pandar_msg` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ source /opt/ros/${ROS_DISTRO}/setup.sh
 sudo apt install -y ros-${ROS_DISTRO}-sensor-msgs-py ros-${ROS_DISTRO}-rosbag2-storage-mcap ros-${ROS_DISTRO}-radar-msgs
 
 mkdir src -p && vcs import src < build_depends.repos
-colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to tier4_perception_msgs
+colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to tier4_perception_msgs pandar_msgs
 source ./install/setup.bash
 ```
 

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -7,6 +7,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
     version: main
+  nebula:
+    type: git
+    url: https://github.com/tier4/nebula.git
+    version: main
 
   # This repository should eventually be removed. See https://github.com/orgs/autowarefoundation/discussions/3862
   autoware_auto_msgs:

--- a/perception_dataset/rosbag2/rosbag2_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_converter.py
@@ -1,5 +1,5 @@
-import os.path as osp
 import logging
+import os.path as osp
 import re
 import shutil
 import sys
@@ -112,7 +112,9 @@ class Rosbag2Converter:
             except ModuleNotFoundError:
                 logging.warning(f"ModuleNotFoundError: {topic_type}")
             except AttributeError:
-                logging.error(f"AttributeError: {topic_type}. Sourced message type is differ from the one in rosbag. {topic_name} is ignored.")
+                logging.error(
+                    f"AttributeError: {topic_type}. Sourced message type is differ from the one in rosbag. {topic_name} is ignored."
+                )
                 continue
 
             if topic_name == "/tf_static":

--- a/perception_dataset/rosbag2/rosbag2_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_converter.py
@@ -1,4 +1,5 @@
 import os.path as osp
+import logging
 import re
 import shutil
 import sys
@@ -100,20 +101,19 @@ class Rosbag2Converter:
             topic_type = self._topic_name_to_topic_type[topic_name]
             try:
                 msg_type = get_message(topic_type)
+                msg = deserialize_message(data, msg_type)
+                if hasattr(msg, "header"):
+                    message_time: float = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
+                elif hasattr(msg, "transforms"):
+                    message_time: float = (
+                        msg.transforms[0].header.stamp.sec
+                        + msg.transforms[0].header.stamp.nanosec * 1e-9
+                    )
             except ModuleNotFoundError:
-                continue
+                logging.warning(f"ModuleNotFoundError: {topic_type}")
             except AttributeError:
-                print("Sourced message type is differ from the one in rosbag")
+                logging.error(f"AttributeError: {topic_type}. Sourced message type is differ from the one in rosbag. {topic_name} is ignored.")
                 continue
-
-            msg = deserialize_message(data, msg_type)
-            if hasattr(msg, "header"):
-                message_time: float = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
-            elif hasattr(msg, "transforms"):
-                message_time: float = (
-                    msg.transforms[0].header.stamp.sec
-                    + msg.transforms[0].header.stamp.nanosec * 1e-9
-                )
 
             if topic_name == "/tf_static":
                 writer.write(topic_name, data, timestamp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "perception-dataset"
-version = "1.0.9"
+version = "1.0.10"
 description = "TIER IV Perception dataset has modules to convert dataset from rosbag to t4_dataset"
 authors = ["Yusuke Muramatsu <yusuke.muramatsu@tier4.jp>", "Shunsuke Miura <shunsuke.miura@tier4.jp>"]
 


### PR DESCRIPTION
## Description
- Add `nebula` to `build_depends` and modify the build process for the `pandar_msg` package to ensure compatibility and successful compilation.
- Improve rosbag filtering by handling AttributeError exceptions, defaulting to using the record time to ensure robust operation under error conditions.

<!-- Describe the changes -->

## How to review

<!-- Describe the review procedure -->

## How to test

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
