### PR TITLE
feat: support ros2numpy > 0.0.4

### DIFF
--- a/perception_dataset/utils/rosbag2.py
+++ b/perception_dataset/utils/rosbag2.py
@@ -112,10 +112,10 @@ def pointcloud_msg_to_numpy(pointcloud_msg: PointCloud2) -> NDArray:
     # Convert the PointCloud2 message to a numpy structured array
     if hasattr(rnp.point_cloud2, "pointcloud2_to_array"):
         points = rnp.point_cloud2.pointcloud2_to_array(pointcloud_msg)
-        xyz = np.vstack((points['x'], points['y'], points['z'])).T
+        xyz = np.vstack((points["x"], points["y"], points["z"])).T
 
-        if 'intensity' in points.dtype.names:
-            intensity = points['intensity'].reshape(-1, 1)
+        if "intensity" in points.dtype.names:
+            intensity = points["intensity"].reshape(-1, 1)
             points_arr = np.hstack((xyz, intensity))
         else:
             points_arr = xyz


### PR DESCRIPTION
## Description
Supporting current version of [ros2_numpy](https://github.com/Box-Robotics/ros2_numpy/tree/v2.0.11) package, instead of [old](https://github.com/nitesh-subedi/ros2_numpy/tree/c34b9e38bd6fb8fccb1f2725cb4e6a1fd5a39846)

This change allows also to work with both the [driving log replayer](https://github.com/tier4/driving_log_replayer/blob/develop/docs/quick_start/installation.en.md#how-to-build) and t4_perception_dataset