### PR TITLE
fix(convert_rosbag2_with_gt_to_annotated_t4_tlr): change init end_timestamp and define delay_msec

### DIFF
--- a/config/rosbag2_to_t4/convert_rosbag2_with_gt_to_annotated_t4_tlr.yaml
+++ b/config/rosbag2_to_t4/convert_rosbag2_with_gt_to_annotated_t4_tlr.yaml
@@ -2,9 +2,9 @@ task: convert_rosbag2_with_gt_to_annotated_t4_tlr
 conversion:
   overwrite_mode: true
   # path to rosbag dir output by simulator
-  input_base: ./data/rosbag2
-  output_base: ./data/t4_annotated
-  gt_label_base: ./data/tlr_label
+  input_base: /media/masatosaeki/ssd0/tmp_dataset/ba4ad2f3-4a99-4c3c-8c84-95e703759360/rosbag2
+  output_base: /media/masatosaeki/ssd0/tmp_dataset/ba4ad2f3-4a99-4c3c-8c84-95e703759360/t4_annotated
+  gt_label_base: /media/masatosaeki/ssd0/tmp_dataset/ba4ad2f3-4a99-4c3c-8c84-95e703759360/tlr_label
   topic_list: ./config/rosbag2_to_t4/topic_list_tlr.yaml
   skip_timestamp: 2
   num_load_frames: 0
@@ -12,7 +12,9 @@ conversion:
   camera_sensors:
     - topic: /sensing/camera/camera6/image_raw/compressed
       channel: CAM_TRAFFIC_LIGHT_FAR
+      delay_msec: 0.0
     - topic: /sensing/camera/camera7/image_raw/compressed
       channel: CAM_TRAFFIC_LIGHT_NEAR
+      delay_msec: 0.0
   generate_frame_every: 1
   generate_frame_every_meter: 0

--- a/config/rosbag2_to_t4/convert_rosbag2_with_gt_to_annotated_t4_tlr.yaml
+++ b/config/rosbag2_to_t4/convert_rosbag2_with_gt_to_annotated_t4_tlr.yaml
@@ -2,9 +2,9 @@ task: convert_rosbag2_with_gt_to_annotated_t4_tlr
 conversion:
   overwrite_mode: true
   # path to rosbag dir output by simulator
-  input_base: /media/masatosaeki/ssd0/tmp_dataset/ba4ad2f3-4a99-4c3c-8c84-95e703759360/rosbag2
-  output_base: /media/masatosaeki/ssd0/tmp_dataset/ba4ad2f3-4a99-4c3c-8c84-95e703759360/t4_annotated
-  gt_label_base: /media/masatosaeki/ssd0/tmp_dataset/ba4ad2f3-4a99-4c3c-8c84-95e703759360/tlr_label
+  input_base: ./data/rosbag2
+  output_base: ./data/t4_annotated
+  gt_label_base: ./data/tlr_label
   topic_list: ./config/rosbag2_to_t4/topic_list_tlr.yaml
   skip_timestamp: 2
   num_load_frames: 0

--- a/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
@@ -108,7 +108,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
         self._lidar_latency: float = params.lidar_latency_sec
         self._lidar_points_ratio_threshold: float = params.lidar_points_ratio_threshold
         self._start_timestamp: float = params.start_timestamp_sec
-        self._end_timestamp: float = 0
+        self._end_timestamp: float = sys.float_info.max
         self._data_type: DataType = params.data_type
         self._ignore_no_ego_transform_at_rosbag_beginning: bool = (
             params.ignore_no_ego_transform_at_rosbag_beginning


### PR DESCRIPTION
## Description
This PR contains the following.
- fix initial `self._end_timestamp` in `_Rosbag2ToNonAnnotatedT4Converter`
- define `delay_mseg` in `config/rosbag2_to_t4/convert_rosbag2_with_gt_to_annotated_t4_tlr.yaml`

<!-- Describe the changes -->

## How to review
None

<!-- Describe the review procedure -->

## How to test
None

### test data
None
<!-- Describe test data -->

### test command
None
<!-- Describe how to test this PR. -->

```bash

```

## Reference
None
<!-- Please write external reference if any. -->

## Notes for reviewer
I checked t4_dataset which is made by this PR on DLR in my local environment and confirmed it work correctly.
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
