### PR TITLE
feat(t4 devkit): add support of saving rendering result as `.rrd`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1331,16 +1331,16 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rerun-sdk"
-version = "0.16.1"
+version = "0.17.0"
 description = "The Rerun Logging SDK"
 optional = false
 python-versions = "<3.13,>=3.8"
 files = [
-    {file = "rerun_sdk-0.16.1-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:170c6976634008611753e10dfef8cdc395ce8180e634c169e7c61cef2f89a277"},
-    {file = "rerun_sdk-0.16.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:c9a76eab7eb5559276737dad655200e9350df0837158dbc5a896970ab4201454"},
-    {file = "rerun_sdk-0.16.1-cp38-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:4d6436752d57e8b8038489a0e7e37f0c760b088e96db5fb81667d3a376d63fea"},
-    {file = "rerun_sdk-0.16.1-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:37b7b47948471873e84f224b16f417a94a91c7cbd6c72c68281eeff1ba414b8f"},
-    {file = "rerun_sdk-0.16.1-cp38-abi3-win_amd64.whl", hash = "sha256:be88799c8afdf68eafa99e64e2e4f0a484e187e017a180219abbe6bb988acd4e"},
+    {file = "rerun_sdk-0.17.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:abd34f746eada83b8bb0bc50007183151981d7ccf18306f3d42165819a3f6fcb"},
+    {file = "rerun_sdk-0.17.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:8b0a8a6feab3f8e679801d158216a71d88a81480021587719330f50d083c4d26"},
+    {file = "rerun_sdk-0.17.0-cp38-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:ad55807abafb01e527846742e087819aac8e103f1ec15aadc563a4038bb44e1d"},
+    {file = "rerun_sdk-0.17.0-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:9d41f1f475270b1e0d50ddb8cb62e0d828988f0c371ac8457af25c8be5aa1dc0"},
+    {file = "rerun_sdk-0.17.0-cp38-abi3-win_amd64.whl", hash = "sha256:34e5595a326cbdddfebdf00b08e877358c564fce74cc8c6d617fc89ef3a6aa70"},
 ]
 
 [package.dependencies]
@@ -1351,6 +1351,7 @@ pyarrow = ">=14.0.2"
 typing-extensions = ">=4.5"
 
 [package.extras]
+notebook = ["rerun-notebook (==0.17.0)"]
 tests = ["pytest (==7.1.2)"]
 
 [[package]]
@@ -1518,7 +1519,7 @@ develop = false
 
 [package.dependencies]
 nuscenes-devkit = "^1.1.11"
-rerun-sdk = "^0.16.1"
+rerun-sdk = "0.17.0"
 
 [package.source]
 type = "directory"

--- a/t4-devkit/docs/tutorials/render.md
+++ b/t4-devkit/docs/tutorials/render.md
@@ -34,3 +34,17 @@
     >>> t4.render_pointcloud(scene_token, ignore_distortion=True)
     ```
 <!-- prettier-ignore-end -->
+
+## Save Recording
+
+You can save the rendering result as follows:
+
+```python
+>>> t4.render_scene(scene_token, save_dir=<DIR_TO_SAVE>)
+```
+
+If you don't want to spawn the viewer, please specify `show=False` as below:
+
+```python
+>>> t4.render_scene(scene_token, save_dir=<DIR_TO_SAVE>, show=False)
+```

--- a/t4-devkit/pyproject.toml
+++ b/t4-devkit/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{ include = "t4_devkit" }]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
-rerun-sdk = "^0.16.1"
+rerun-sdk = "0.17.0"
 nuscenes-devkit = "^1.1.11"
 
 [tool.poetry.group.dev.dependencies]

--- a/t4-devkit/t4_devkit/tier4.py
+++ b/t4-devkit/t4_devkit/tier4.py
@@ -18,6 +18,8 @@ from t4_devkit.common.timestamp import sec2us, us2sec
 from t4_devkit.schema import SchemaName, SensorModality, VisibilityLevel, build_schema
 
 if TYPE_CHECKING:
+    from rerun.blueprint.api import BlueprintLike
+    from rerun.recording_stream import RecordingStream
     from t4_devkit.typing import (
         CamIntrinsicType,
         NDArrayF64,
@@ -615,56 +617,27 @@ class Tier4:
 
         return points_on_img, depths, np.array(img, dtype=np.uint8)
 
-    def render_scene(self, scene_token: str, max_time_seconds: float = np.inf) -> None:
+    def render_scene(
+        self,
+        scene_token: str,
+        *,
+        max_time_seconds: float = np.inf,
+        save_dir: str | None = None,
+        show: bool = True,
+    ) -> None:
         """Render specified scene.
 
         Args:
             scene_token (str): Unique identifier of scene.
             max_time_seconds (float, optional): Max time length to be rendered [s].
+            save_dir (str | None, optional): Directory path to save the recording.
+            show (bool, optional): Whether to spawn rendering viewer.
 
         BUG:
             If sample data is not associated with the first sample, all frames are not rendered.
         """
-        # TODO: refactoring initialization of rerun
-        camera_names = [
-            sensor.channel for sensor in self.sensor if sensor.modality == SensorModality.CAMERA
-        ]
-
-        sensor_space_views = [
-            rrb.Spatial2DView(name=camera, origin=f"world/ego_vehicle/{camera}")
-            for camera in camera_names
-        ]
-        blueprint = rrb.Vertical(
-            rrb.Horizontal(
-                rrb.Spatial3DView(name="3D", origin="world"),
-                rrb.TextDocumentView(origin="description", name="Description"),
-                column_shares=[3, 1],
-            ),
-            rrb.Grid(*sensor_space_views),
-            row_shares=[4, 2],
-        )
-        rr.init(
-            application_id=f"t4-devkit@{scene_token}",
-            recording_id=None,
-            spawn=True,
-            default_enabled=True,
-            strict=True,
-            default_blueprint=blueprint,
-        )
-
-        # render scene
-        rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
-
-        rr.log(
-            "world",
-            rr.AnnotationContext(
-                [
-                    rr.AnnotationInfo(id=label_id, label=label)
-                    for label, label_id in self._label2id.items()
-                ]
-            ),
-            static=True,
-        )
+        application_id = f"t4-devkit@{scene_token}"
+        blueprint = self._init_viewer(application_id, render_annotation=True, spawn=show)
 
         scene: Scene = self.get("scene", scene_token)
         first_sample: Sample = self.get("sample", scene.first_sample_token)
@@ -693,56 +666,29 @@ class Tier4:
         self._render_annotation_3ds(scene.first_sample_token, max_timestamp_us)
         self._render_annotation_2ds(scene.first_sample_token, max_timestamp_us)
 
-    def render_instance(self, instance_token: str) -> None:
+        if save_dir is not None:
+            filepath = osp.join(save_dir, application_id + ".rrd")
+            self._save_viewer(filepath, default_blueprint=blueprint)
+
+    def render_instance(
+        self,
+        instance_token: str,
+        *,
+        save_dir: str | None = None,
+        show: bool = True,
+    ) -> None:
         """Render particular instance.
 
         Args:
             instance_token (str): Instance token.
+            save_dir (str | None, optional): Directory path to save the recording.
+            show (bool, optional): Whether to spawn rendering viewer.
 
         BUG:
             If sample data is not associated with the first sample, all frames are not rendered.
         """
-        # TODO: refactoring initialization of rerun
-        camera_names = [
-            sensor.channel for sensor in self.sensor if sensor.modality == SensorModality.CAMERA
-        ]
-
-        sensor_space_views = [
-            rrb.Spatial2DView(name=camera, origin=f"world/ego_vehicle/{camera}")
-            for camera in camera_names
-        ]
-        blueprint = rrb.Vertical(
-            rrb.Horizontal(
-                rrb.Spatial3DView(name="3D", origin="world"),
-                rrb.TextDocumentView(origin="description", name="Description"),
-                column_shares=[3, 1],
-            ),
-            rrb.Grid(*sensor_space_views),
-            row_shares=[4, 2],
-        )
-
-        rr.init(
-            application_id=f"t4-devkit@{instance_token}",
-            recording_id=None,
-            spawn=True,
-            default_enabled=True,
-            strict=True,
-            default_blueprint=blueprint,
-        )
-
-        # render scene
-        rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
-
-        rr.log(
-            "world",
-            rr.AnnotationContext(
-                [
-                    rr.AnnotationInfo(id=label_id, label=label)
-                    for label, label_id in self._label2id.items()
-                ]
-            ),
-            static=True,
-        )
+        application_id = f"t4-devkit@{instance_token}"
+        blueprint = self._init_viewer(application_id, render_annotation=True, spawn=show)
 
         instance: Instance = self.get("instance", instance_token)
         first_ann: SampleAnnotation = self.get(
@@ -783,52 +729,33 @@ class Tier4:
             instance_token=instance_token,
         )
 
+        if save_dir is not None:
+            filepath = osp.join(save_dir, application_id + ".rrd")
+            self._save_viewer(filepath, default_blueprint=blueprint)
+
     def render_pointcloud(
         self,
         scene_token: str,
-        max_time_seconds: float = np.inf,
         *,
+        max_time_seconds: float = np.inf,
         ignore_distortion: bool = False,
+        save_dir: str | None = None,
+        show: bool = True,
     ) -> None:
         """Render pointcloud on 3D and 2D view.
 
         Args:
             scene_token (str): Scene token.
             max_time_seconds (float, optional): Max time length to be rendered [s].
+            save_dir (str | None, optional): Directory path to save the recording.
             ignore_distortion (bool, optional): Whether to ignore distortion parameters.
+            show (bool, optional): Whether to spawn rendering viewer.
 
         TODO:
             Add an option of rendering radar channels.
         """
-        # TODO: refactoring initialization of rerun
-        camera_names = [
-            sensor.channel for sensor in self.sensor if sensor.modality == SensorModality.CAMERA
-        ]
-
-        sensor_space_views = [
-            rrb.Spatial2DView(name=camera, origin=f"world/ego_vehicle/{camera}")
-            for camera in camera_names
-        ]
-        blueprint = rrb.Vertical(
-            rrb.Horizontal(
-                rrb.Spatial3DView(name="3D", origin="world"),
-                rrb.TextDocumentView(origin="description", name="Description"),
-                column_shares=[3, 1],
-            ),
-            rrb.Grid(*sensor_space_views),
-            row_shares=[4, 2],
-        )
-        rr.init(
-            application_id=f"t4-devkit@{scene_token}",
-            recording_id=None,
-            spawn=True,
-            default_enabled=True,
-            strict=True,
-            default_blueprint=blueprint,
-        )
-
-        # render scene
-        rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
+        application_id = f"t4-devkit@{scene_token}"
+        blueprint = self._init_viewer(application_id, render_annotation=False, spawn=show)
 
         scene: Scene = self.get("scene", scene_token)
         first_sample: Sample = self.get("sample", scene.first_sample_token)
@@ -852,6 +779,92 @@ class Tier4:
             project_points=True,
             ignore_distortion=ignore_distortion,
         )
+
+        if save_dir is not None:
+            filepath = osp.join(save_dir, application_id + ".rrd")
+            self._save_viewer(filepath, default_blueprint=blueprint)
+
+    def _init_viewer(
+        self,
+        application_id: str,
+        *,
+        render_annotation: bool = True,
+        spawn: bool = False,
+    ) -> BlueprintLike:
+        """Initialize rendering viewer.
+
+        Args:
+            application_id (str): Application ID.
+            render_annotation (bool, optional): Whether to render annotations.
+            spawn (bool, optional): Whether to spawn rendering viewer.
+
+        Returns:
+            Recording blueprint.
+        """
+        camera_names = [
+            sensor.channel for sensor in self.sensor if sensor.modality == SensorModality.CAMERA
+        ]
+
+        sensor_space_views = [
+            rrb.Spatial2DView(name=camera, origin=f"world/ego_vehicle/{camera}")
+            for camera in camera_names
+        ]
+        blueprint = rrb.Vertical(
+            rrb.Horizontal(
+                rrb.Spatial3DView(name="3D", origin="world"),
+                rrb.TextDocumentView(origin="description", name="Description"),
+                column_shares=[3, 1],
+            ),
+            rrb.Grid(*sensor_space_views),
+            row_shares=[4, 2],
+        )
+        rr.init(
+            application_id=application_id,
+            recording_id=None,
+            spawn=spawn,
+            default_enabled=True,
+            strict=True,
+            default_blueprint=blueprint,
+        )
+
+        # render scene
+        rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
+
+        if render_annotation:
+            rr.log(
+                "world",
+                rr.AnnotationContext(
+                    [
+                        rr.AnnotationInfo(id=label_id, label=label)
+                        for label, label_id in self._label2id.items()
+                    ]
+                ),
+                static=True,
+            )
+
+        print(f"Finish initializing {application_id} ...")
+
+        return blueprint
+
+    def _save_viewer(
+        self,
+        filepath: str,
+        default_blueprint: BlueprintLike | None = None,
+        recording: RecordingStream | None = None,
+    ) -> None:
+        """Save rendering viewer to `.rrd` file.
+
+        Args:
+            filepath (str): Filepath to save rendering.
+            default_blueprint (BlueprintLike | None, optional): Blueprint of rendering.
+            recording (RecordingStream | None, optional): Recording stream.
+        """
+        ext = osp.splitext(osp.basename(filepath))[-1]
+        if ext != ".rrd":
+            raise ValueError(f"File extension must be .rrd, but got {ext}")
+
+        print(f"Saving rendering record to {filepath} ...")
+        rr.save(filepath, default_blueprint=default_blueprint, recording=recording)
 
     def _render_lidar_and_ego(
         self,

--- a/t4-devkit/t4_devkit/tier4.py
+++ b/t4-devkit/t4_devkit/tier4.py
@@ -929,7 +929,9 @@ class Tier4:
                 )
                 points = pointcloud.points[:3].T  # (N, 3)
                 point_colors = distance_color(np.linalg.norm(points, axis=1))
-                rr.log(f"world/ego_pose/{sensor_name}", rr.Points3D(points, colors=point_colors))
+                rr.log(
+                    f"world/ego_vehicle/{sensor_name}", rr.Points3D(points, colors=point_colors)
+                )
                 current_radar_token = sample_data.next
 
     def _render_cameras(self, first_camera_tokens: list[str], max_timestamp_us: float) -> None:

--- a/t4-devkit/t4_devkit/tier4.py
+++ b/t4-devkit/t4_devkit/tier4.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import os
 import os.path as osp
 import time
 from typing import TYPE_CHECKING
@@ -667,8 +668,7 @@ class Tier4:
         self._render_annotation_2ds(scene.first_sample_token, max_timestamp_us)
 
         if save_dir is not None:
-            filepath = osp.join(save_dir, application_id + ".rrd")
-            self._save_viewer(filepath, default_blueprint=blueprint)
+            self._save_viewer(save_dir, application_id + ".rrd", default_blueprint=blueprint)
 
     def render_instance(
         self,
@@ -730,8 +730,7 @@ class Tier4:
         )
 
         if save_dir is not None:
-            filepath = osp.join(save_dir, application_id + ".rrd")
-            self._save_viewer(filepath, default_blueprint=blueprint)
+            self._save_viewer(save_dir, application_id + ".rrd", default_blueprint=blueprint)
 
     def render_pointcloud(
         self,
@@ -781,8 +780,7 @@ class Tier4:
         )
 
         if save_dir is not None:
-            filepath = osp.join(save_dir, application_id + ".rrd")
-            self._save_viewer(filepath, default_blueprint=blueprint)
+            self._save_viewer(save_dir, application_id + ".rrd", default_blueprint=blueprint)
 
     def _init_viewer(
         self,
@@ -848,20 +846,27 @@ class Tier4:
 
     def _save_viewer(
         self,
-        filepath: str,
+        save_dir: str,
+        filename: str,
         default_blueprint: BlueprintLike | None = None,
         recording: RecordingStream | None = None,
     ) -> None:
         """Save rendering viewer to `.rrd` file.
 
         Args:
-            filepath (str): Filepath to save rendering.
+            save_dir (str): Directory path to save the recording.
+            filename (str): Filepath to save rendering.
             default_blueprint (BlueprintLike | None, optional): Blueprint of rendering.
             recording (RecordingStream | None, optional): Recording stream.
         """
-        ext = osp.splitext(osp.basename(filepath))[-1]
+        ext = osp.splitext(osp.basename(filename))[-1]
         if ext != ".rrd":
             raise ValueError(f"File extension must be .rrd, but got {ext}")
+
+        if not osp.exists(save_dir):
+            os.makedirs(save_dir)
+
+        filepath = osp.join(save_dir, filename)
 
         print(f"Saving rendering record to {filepath} ...")
         rr.save(filepath, default_blueprint=default_blueprint, recording=recording)


### PR DESCRIPTION
## Description

<!-- Describe the changes -->

After this PR, users can save rendering result as follows:

```python
from t4_devkit import Tier4

t4 = Tier4("annotation", "<DATASET_PATH>")

# Rendering scene 
scene_token = t4.scene[0].token
t4.render_scene(scene_token, save_dir="<DIR_TO_SAVE>")
# -> Rendering result will be saved to `save_dir/<AppID>.rrd`
```

Also, we can suspend to spawn a viewer by specifying `show=False` as below:

```python
t4.render_scene(scene_token, save_dir="<DIR_TO_SAVE>", show=False)
```

Note that, both `save_dir` and `show` are keyword-only arguments.

## How to review

<!-- Describe the review procedure -->

Check whether each rendering method works including `render_scene(...)/render_instance(...)/render_point_cloud(...)`.

## How to test

### test data

<!-- Describe test data -->

[TIER IV INTERNAL LINK](https://console.data-search.tier4.jp/projects/prd_jt/t4datasets/d20b53bf-8b4e-4040-9d2c-6df22120177a?version=2)

### test command

<!-- Describe how to test this PR. -->

```python
from t4_devkit import Tier4

t4 = Tier4("annotation", "<DATASET_PATH>")

# Rendering scene 
scene_token = t4.scene[0].token
t4.render_scene(scene_token, save_dir="<DIR_TO_SAVE>")
# -> Rendering result will be saved to `save_dir/<AppID>.rrd`

# Other rendering methods
# ...
```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

This PR fixes `rerun=0.17.0` because some breaking changes are contained in the release of `v0.18.0`: https://github.com/rerun-io/rerun/releases/tag/0.18.0.


**Edited on Aug 20**
Please update your dependency first as follows:

```shell
poetry update t4-devkit
```