### PR TITLE
feat (fastlabel): add project information to the label

### DIFF
--- a/perception_dataset/fastlabel/download_annotations.py
+++ b/perception_dataset/fastlabel/download_annotations.py
@@ -89,6 +89,9 @@ def download_completed_annotations(
                 task["name"] = rename_image_task_name(task["name"])
                 completed_tasks.append(task)
                 each_task_file_name = task["name"].replace(" ", "_").replace("/", "_") + ".json"
+                task["project_name"] = project["name"]
+                task["project_slug"] = project["slug"]
+                task["project_id"] = project["id"]
                 if save_each:
                     with open(osp.join(output_dir, each_task_file_name), "w") as f:
                         json.dump([task], f, indent=4)


### PR DESCRIPTION
This pull request includes a change to the `download_completed_annotations` function in the `perception_dataset/fastlabel/download_annotations.py` file. The change adds project details to each task before saving them.

Enhancements to task details:

* [`perception_dataset/fastlabel/download_annotations.py`](diffhunk://#diff-8f4c0ad8eae73929e687030b1521a4cf70e53bbaf0bd593dc46c2a4ba8ba0111R92-R94): Added `project_name`, `project_slug`, and `project_id` to each task in the `download_completed_annotations` function.