### PR TITLE
feat(fast_label): udpate rename_task to support TLR task name

### DIFF
--- a/perception_dataset/fastlabel/download_annotations.py
+++ b/perception_dataset/fastlabel/download_annotations.py
@@ -70,10 +70,16 @@ def rename_image_task_name(name: str) -> str:
     if "_CAM_" not in name:
         return name
     base_name, camera_info = name.split("CAM_")
-    dataset_name, index = base_name.split("/")
-    frame_index = index[:5]
-    camera_name, ext = os.path.splitext(camera_info)
-    new_file_name = f"{dataset_name}/CAM_{camera_name}/{frame_index}{ext}"
+    print(f"base_name: {base_name}, camera_info: {camera_info}")
+    if base_name.count("/") != 1 and base_name.startswith("data"):
+        dataset_name = base_name.split("__")[1]
+        camera_name, filename = camera_info.split("__")
+        new_file_name = f"{dataset_name}/CAM_{camera_name}/{filename}"
+    else:
+        dataset_name, index = base_name.split("/")
+        frame_index = index[:5]
+        camera_name, ext = os.path.splitext(camera_info)
+        new_file_name = f"{dataset_name}/CAM_{camera_name}/{frame_index}{ext}"
     return new_file_name
 
 


### PR DESCRIPTION
This pull request includes a change to the `rename_image_task_name` function in the `perception_dataset/fastlabel/download_annotations.py` file. The change introduces additional logic to handle cases where the `base_name` does not follow a specific format.

Key change:

* [`perception_dataset/fastlabel/download_annotations.py`](diffhunk://#diff-8f4c0ad8eae73929e687030b1521a4cf70e53bbaf0bd593dc46c2a4ba8ba0111R73-R78): Added a print statement for debugging and additional logic to handle cases where `base_name` does not start with "data" and does not have exactly one "/" character.