### PR TITLE
fix: resolve ValueError if there is no observed NavSatFix messages

### DIFF
--- a/perception_dataset/ros2/oxts_msgs/ins_handler.py
+++ b/perception_dataset/ros2/oxts_msgs/ins_handler.py
@@ -418,19 +418,20 @@ class INSHandler:
     def get_imus(self) -> List[Imu]:
         return self._buffer["imu"]
 
-    def lookup_nav_sat_fixes(self, stamp: RosTime) -> NavSatFix:
+    def lookup_nav_sat_fixes(self, stamp: RosTime) -> Optional[NavSatFix]:
         return self.interpolate_nav_sat_fixes(stamp)
 
     def interpolate_nav_sat_fixes(
         self, query_stamp: Union[RosTime, List[RosTime]]
-    ) -> Union[NavSatFix | List[NavSatFix]]:
+    ) -> Optional[Union[NavSatFix | List[NavSatFix]]]:
         """Interpolate NavSatFix.
 
         Args:
             query_stamp (RosTime | List[RosTime]): Query stamp(s).
 
         Returns:
-            Union[NavSatFix, List[NavSatFix]]: Interpolated message(s).
+            Optional[Union[NavSatFix, List[NavSatFix]]]: Interpolated message(s).
+                Note that it returns `None`, if there is no observed NavSatFix messages.
 
         Warnings:
             If the value in `query_stamps` is out of range of the observed timestamps,
@@ -453,6 +454,9 @@ class INSHandler:
         for msg in observed:
             timestamps.append(stamp_to_unix_timestamp(msg.header.stamp))
             geo_coordinates.append((msg.latitude, msg.longitude, msg.altitude))
+
+        if len(timestamps) == 0:
+            return None
 
         if min(query_timestamps) < min(timestamps) or max(timestamps) < max(query_timestamps):
             warnings.warn(

--- a/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
@@ -872,11 +872,15 @@ class _Rosbag2ToNonAnnotatedT4Converter:
                     "ay": ego_state.accel.y,
                     "az": ego_state.accel.z,
                 },
-                geocoordinate={
-                    "latitude": geocoordinate.latitude,
-                    "longitude": geocoordinate.longitude,
-                    "altitude": geocoordinate.altitude,
-                },
+                geocoordinate=(
+                    {
+                        "latitude": geocoordinate.latitude,
+                        "longitude": geocoordinate.longitude,
+                        "altitude": geocoordinate.altitude,
+                    }
+                    if geocoordinate is not None
+                    else None
+                ),
             )
         else:
             transform_stamped = self._bag_reader.get_transform_stamped(


### PR DESCRIPTION
## Description

<!-- Describe the changes -->

This PR deals with the cases that `NavSatFix` message is not included in RosBag.

Before this PR, the following error has been raised in this case:

![image](https://github.com/user-attachments/assets/3056baa0-40f2-4008-8459-bb730e810f1c)

In order to deal with this problem, as of this PR, interpolation will be skipped and all `geocoordinate` fields will be filled by `None` as follows:

```json
    [
       {
           "token": "922dd1d3795848398cd258ce6011969a",
           "translation": [
               6371.679376965268,
               14683.198967615801,
              -114.74298987091399
             ],
          "rotation": [
             -0.0011899695839468949,
              0.927482095564976,
              -0.3738644686696874,
              0.0009515488019675177
         ],
           "timestamp": 1724915739299722,
           "twist": [
               19.191881914181405,
               -0.32103013858398094,
               -0.285456699862336,
               0.9235548267151779,
               0.2642397397715217,
               0.32006239842098405
           ],
           "acceleration": [
               -0.3131694334716736,
                0.11359620433402622,
                -10.569883635372245
            ],
         "geocoordinate": null
  },
```


## How to review

<!-- Describe the review procedure -->

## How to test

### test data

<!-- Describe test data -->

[TIER IV INTERNAL LINK](https://drive.google.com/drive/folders/1vW6SjRy8R_nFSaqlIGZpqfIYGdrOqmFk)

### test command

<!-- Describe how to test this PR. -->

```bash
python3 -mperception_dataset.convert --config config/convert_comlops_rosbag2_to_non_annotated_t4_sample.yaml
```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
