### PR TITLE
feat: enhance surface category handling in AnnotationFilesGenerator and DeepenToT4Converter

### DIFF
--- a/perception_dataset/deepen/deepen_to_t4_converter.py
+++ b/perception_dataset/deepen/deepen_to_t4_converter.py
@@ -4,9 +4,9 @@ from pathlib import Path
 import re
 import shutil
 from typing import Any, Dict, List, Optional, Union
-import yaml
 
 from nuscenes.nuscenes import NuScenes
+import yaml
 
 from perception_dataset.abstract_converter import AbstractConverter
 from perception_dataset.deepen.deepen_annotation import (
@@ -118,7 +118,9 @@ class DeepenToT4Converter(AbstractConverter):
             output_dir = osp.join(self._output_base, t4data_name, self._t4_dataset_dir_name)
             input_dir = osp.join(self._input_base, t4data_name)
 
-            annotation_files_generator = AnnotationFilesGenerator(description=self._description, surface_categories=self._surface_categories)
+            annotation_files_generator = AnnotationFilesGenerator(
+                description=self._description, surface_categories=self._surface_categories
+            )
             annotation_files_generator.convert_one_scene(
                 input_dir=input_dir,
                 output_dir=output_dir,

--- a/perception_dataset/deepen/deepen_to_t4_converter.py
+++ b/perception_dataset/deepen/deepen_to_t4_converter.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import re
 import shutil
 from typing import Any, Dict, List, Optional, Union
+import yaml
 
 from nuscenes.nuscenes import NuScenes
 
@@ -57,6 +58,11 @@ class DeepenToT4Converter(AbstractConverter):
         self._label_info: Optional[LabelInfo] = label_info
 
         self._topic_list_yaml: Union[List, Dict] = topic_list
+        if description.get("surface_categories"):
+            with open(description["surface_categories"], "r") as f:
+                self._surface_categories: List[str] = yaml.safe_load(f)
+        else:
+            self._surface_categories = []
 
     def convert(self):
         camera_index: Dict[str, int] = self._description["camera_index"]
@@ -111,7 +117,8 @@ class DeepenToT4Converter(AbstractConverter):
         for t4data_name, dataset_id in self._t4data_name_to_deepen_dataset_id.items():
             output_dir = osp.join(self._output_base, t4data_name, self._t4_dataset_dir_name)
             input_dir = osp.join(self._input_base, t4data_name)
-            annotation_files_generator = AnnotationFilesGenerator(description=self._description)
+
+            annotation_files_generator = AnnotationFilesGenerator(description=self._description, surface_categories=self._surface_categories)
             annotation_files_generator.convert_one_scene(
                 input_dir=input_dir,
                 output_dir=output_dir,

--- a/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
+++ b/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
@@ -226,7 +226,7 @@ class FastLabel2dToT4Converter(DeepenToT4Converter):
                                 "sensor_id": self._camera2idx[camera],
                             }
                         )
-                        if self._label_converter.is_object_label(category_label):
+                        if self._label_converter.is_object_label(category_label) and category_label not in self._surface_categories:
                             label_t4_dict["two_d_box"] = _convert_polygon_to_bbox(
                                 a["points"][0][0]
                             )

--- a/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
+++ b/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
@@ -226,7 +226,10 @@ class FastLabel2dToT4Converter(DeepenToT4Converter):
                                 "sensor_id": self._camera2idx[camera],
                             }
                         )
-                        if self._label_converter.is_object_label(category_label) and category_label not in self._surface_categories:
+                        if (
+                            self._label_converter.is_object_label(category_label)
+                            and category_label not in self._surface_categories
+                        ):
                             label_t4_dict["two_d_box"] = _convert_polygon_to_bbox(
                                 a["points"][0][0]
                             )

--- a/perception_dataset/t4_dataset/annotation_files_generator.py
+++ b/perception_dataset/t4_dataset/annotation_files_generator.py
@@ -25,7 +25,12 @@ from perception_dataset.utils.calculate_num_points import calculate_num_points
 
 
 class AnnotationFilesGenerator:
-    def __init__(self, with_camera: bool = True, description: Dict[str, Dict[str, str]] = {}, surface_categories: List[str] = []):
+    def __init__(
+        self,
+        with_camera: bool = True,
+        description: Dict[str, Dict[str, str]] = {},
+        surface_categories: List[str] = [],
+    ):
         # TODO(yukke42): remove the hard coded attribute description
         self._attribute_table = AttributeTable(
             name_to_description={},

--- a/perception_dataset/t4_dataset/annotation_files_generator.py
+++ b/perception_dataset/t4_dataset/annotation_files_generator.py
@@ -26,7 +26,7 @@ from perception_dataset.utils.calculate_num_points import calculate_num_points
 
 
 class AnnotationFilesGenerator:
-    def __init__(self, with_camera: bool = True, description: Dict[str, Dict[str, str]] = {}):
+    def __init__(self, with_camera: bool = True, description: Dict[str, Dict[str, str]] = {}, surface_categories: List[str] = []):
         # TODO(yukke42): remove the hard coded attribute description
         self._attribute_table = AttributeTable(
             name_to_description={},
@@ -62,12 +62,7 @@ class AnnotationFilesGenerator:
         else:
             self._camera2idx = None
         self._with_lidar = description.get("with_lidar", True)
-
-        if description.get("surface_categories"):
-            with open(description["surface_categories"], "r") as f:
-                self._surface_categories: List[str] = yaml.safe_load(f)
-        else:
-            self._surface_categories = []
+        self._surface_categories: List[str] = surface_categories
 
     def save_tables(self, anno_dir: str):
         for cls_attr in self.__dict__.values():

--- a/perception_dataset/t4_dataset/annotation_files_generator.py
+++ b/perception_dataset/t4_dataset/annotation_files_generator.py
@@ -8,7 +8,6 @@ from nuimages import NuImages
 import numpy as np
 from nuscenes.nuscenes import NuScenes
 from pycocotools import mask as cocomask
-import yaml
 
 from perception_dataset.constants import SENSOR_ENUM
 from perception_dataset.t4_dataset.classes.abstract_class import AbstractTable


### PR DESCRIPTION

## Description
This pull request includes changes to the `perception_dataset` module, particularly focusing on handling surface categories in the dataset conversion process. The most important changes include importing the `yaml` module, updating the constructor and methods to handle surface categories, and modifying the annotation file generation process.

Handling surface categories:

* [`perception_dataset/deepen/deepen_to_t4_converter.py`](diffhunk://#diff-b9dca63cb1e60433c3a55405c357fd22725664db75d3fc2b60d5359f3c21f382R7): Imported the `yaml` module to handle YAML files.
* [`perception_dataset/deepen/deepen_to_t4_converter.py`](diffhunk://#diff-b9dca63cb1e60433c3a55405c357fd22725664db75d3fc2b60d5359f3c21f382R61-R65): Updated the constructor to load surface categories from a YAML file if specified in the description.
* [`perception_dataset/deepen/deepen_to_t4_converter.py`](diffhunk://#diff-b9dca63cb1e60433c3a55405c357fd22725664db75d3fc2b60d5359f3c21f382L114-R121): Modified the `convert` method to pass surface categories to the `AnnotationFilesGenerator`.
* [`perception_dataset/t4_dataset/annotation_files_generator.py`](diffhunk://#diff-fac1549fee35456230639e4509376e507433df7e35a18c55c57a437c56cae050L29-R29): Updated the constructor to accept surface categories as a parameter and removed the redundant code for loading surface categories from the description. [[1]](diffhunk://#diff-fac1549fee35456230639e4509376e507433df7e35a18c55c57a437c56cae050L29-R29) [[2]](diffhunk://#diff-fac1549fee35456230639e4509376e507433df7e35a18c55c57a437c56cae050L65-R65)

Filtering annotations based on surface categories:

* [`perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py`](diffhunk://#diff-62be1a85945bd3f154e4f5fab6110b0c100c0ad712dd83c0b675a4875f4190c3L229-R229): Modified the `_format_fastlabel_annotation` method to filter out annotations with category labels that are surface categories.