### PR TITLE
refactor(deepen/download_annotations): minor fix for more user friendly tool

### DIFF
--- a/perception_dataset/deepen/download_annotations.py
+++ b/perception_dataset/deepen/download_annotations.py
@@ -15,6 +15,7 @@ DATASETS_URL = (
 
 today = str(date.today()).replace("-", "")
 
+
 def get_datasets(dataset_ids: List[str], dataset_dir: str, output_name: str):
     headers = {
         "Authorization": f"Bearer {ACCESS_TOKEN}",

--- a/perception_dataset/deepen/download_annotations.py
+++ b/perception_dataset/deepen/download_annotations.py
@@ -9,24 +9,11 @@ import yaml
 
 CLIENT_ID = os.environ["DEEPEN_CLIENT_ID"]
 ACCESS_TOKEN = os.environ["DEEPEN_ACCESS_TOKEN"]
-DATSETS_URL = (
+DATASETS_URL = (
     f"https://tools.deepen.ai/api/v2/clients/{CLIENT_ID}/labels_of_dataset_ids?labelSetId=default"
 )
 
 today = str(date.today()).replace("-", "")
-
-
-# def get_dataset():
-#     URL = f"https://tools.deepen.ai/api/v2/datasets/{DATASET_ID}/labels?filter_existing_categories=true&final=true&all=true"
-#     print(URL)
-
-#     headers = {
-#         "Authorization": f"Bearer {os.environ['DEEPEN_ACCESS_TOKEN']}",
-#     }
-#     response = requests.get(URL, headers=headers)
-#     print(response.status_code)
-#     pprint(response.json())
-
 
 def get_datasets(dataset_ids: List[str], dataset_dir: str, output_name: str):
     headers = {
@@ -36,7 +23,7 @@ def get_datasets(dataset_ids: List[str], dataset_dir: str, output_name: str):
     data = {"dataset_ids": dataset_ids}
 
     try:
-        response = requests.post(DATSETS_URL, headers=headers, data=json.dumps(data))
+        response = requests.post(DATASETS_URL, headers=headers, data=json.dumps(data))
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
         raise SystemExit(e)
@@ -72,5 +59,7 @@ if __name__ == "__main__":
     ), f"use config file of convert_deepen_to_t4 task: {config['task']}"
     dataset_ids = list(config["conversion"]["dataset_corresponding"].values())
     output_name = config["conversion"]["input_anno_file"]
+
+    print("Requesting annotated json for: ", dataset_ids)
 
     get_datasets(dataset_ids, args.output_dir, output_name)


### PR DESCRIPTION
## Description
Minor refactoring for deepen/download_annotations
<!-- Describe the changes -->

## How to review
Please follow the document to run the download_annotations script.
<!-- Describe the review procedure -->

## How to test

### test data

```yaml
task: convert_deepen_to_t4
description:
  visibility:
    full: "No occlusion of the object."
    most: "Object is occluded, but by less than 50%."
    partial: "The object is occluded by more than 50% (but not completely)."
    none: "The object is 90-100% occluded and no points/pixels are visible in the label."
  camera_index:
    CAM_FRONT: 0
    CAM_FRONT_RIGHT: 1
    CAM_BACK_RIGHT: 2
    CAM_BACK: 3
    CAM_BACK_LEFT: 4
    CAM_FRONT_LEFT: 5

conversion:
  input_base: ./data/non_annotated_t4_format
  input_anno_file: ./data/deepen_format/hoge.json
  input_bag_base: ./data/rosbag2
  output_base: ./data/t4_format
  topic_list: ./config/topic_list.yaml
  ignore_interpolate_label: False
  dataset_corresponding:
    fuga: ng9nuEQJstFE7X783rxSqXMc
```
```bash
$ python3 -m perception_dataset.deepen.download_annotations --config config/convert_deepen_to_t4_sample.yaml
```

And you would get
```bash
Requesting annotated json for:  ['ng9nuEQJstFE7X783rxSqXMc']
Annotation file is saved: ././data/deepen_format/lidar_annotations_accepted_deepen.json
```

<!-- Describe test data -->
## Reference
None
<!-- Please write external reference if any. -->

## Notes for reviewer
None
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
