### PR TITLE
refactor: parallelizate fl annotation processing 

### DIFF
--- a/perception_dataset/deepen/deepen_to_t4_converter.py
+++ b/perception_dataset/deepen/deepen_to_t4_converter.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import re
 import shutil
 from typing import Any, Dict, List, Optional, Union
-import yaml
 
 from nuscenes.nuscenes import NuScenes
 import yaml

--- a/perception_dataset/deepen/deepen_to_t4_converter.py
+++ b/perception_dataset/deepen/deepen_to_t4_converter.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import re
 import shutil
 from typing import Any, Dict, List, Optional, Union
+import yaml
 
 from nuscenes.nuscenes import NuScenes
 import yaml

--- a/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
+++ b/perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py
@@ -218,16 +218,23 @@ class FastLabel2dToT4Converter(DeepenToT4Converter):
 
         # bbox or segmentation type processing
         if a["type"] == "bbox":
-            label_t4_dict.update({
-                "two_d_box": a["points"],
-                "sensor_id": self._camera2idx[camera],
-            })
+            label_t4_dict.update(
+                {
+                    "two_d_box": a["points"],
+                    "sensor_id": self._camera2idx[camera],
+                }
+            )
         elif a["type"] == "segmentation":
-            label_t4_dict.update({
-                "two_d_segmentation": _rle_from_points(a["points"], width, height),
-                "sensor_id": self._camera2idx[camera],
-            })
-            if self._label_converter.is_object_label(category_label) and category_label not in self._surface_categories:
+            label_t4_dict.update(
+                {
+                    "two_d_segmentation": _rle_from_points(a["points"], width, height),
+                    "sensor_id": self._camera2idx[camera],
+                }
+            )
+            if (
+                self._label_converter.is_object_label(category_label)
+                and category_label not in self._surface_categories
+            ):
                 label_t4_dict["two_d_box"] = _convert_polygon_to_bbox(a["points"][0][0])
                 print(f"Converted polygon to bbox for {category_label}")
 
@@ -249,7 +256,9 @@ class FastLabel2dToT4Converter(DeepenToT4Converter):
 
                 for a in ann["annotations"]:
                     futures.append(
-                        executor.submit(self.process_annotation, a, frame_no, camera, width, height)
+                        executor.submit(
+                            self.process_annotation, a, frame_no, camera, width, height
+                        )
                     )
 
             for future in as_completed(futures):
@@ -257,6 +266,7 @@ class FastLabel2dToT4Converter(DeepenToT4Converter):
                 file_annotations[file_id].append(label_t4_dict)
 
         return file_annotations
+
 
 def _rle_from_points(points: Points2DLike, width: int, height: int) -> Dict[str, Any]:
     """Encode points to RLE format mask.


### PR DESCRIPTION
This pull request introduces parallel processing to the `fastlabel_2d_to_t4_converter.py` to improve the performance of annotation processing. The most important changes include importing necessary modules for parallel processing, refactoring the annotation formatting function, and adding new methods to handle parallel processing.

Parallel processing improvements:

* [`perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py`](diffhunk://#diff-62be1a85945bd3f154e4f5fab6110b0c100c0ad712dd83c0b675a4875f4190c3R3): Imported `ProcessPoolExecutor` and `as_completed` from `concurrent.futures` to enable parallel processing.
* [`perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py`](diffhunk://#diff-62be1a85945bd3f154e4f5fab6110b0c100c0ad712dd83c0b675a4875f4190c3L178-R259): Refactored `_format_fastlabel_annotation` to process annotations for each file in parallel using the new `_process_annotations_for_file` method.
* [`perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py`](diffhunk://#diff-62be1a85945bd3f154e4f5fab6110b0c100c0ad712dd83c0b675a4875f4190c3L178-R259): Added `process_annotation` method to handle individual annotation processing tasks.
* [`perception_dataset/fastlabel_to_t4/fastlabel_2d_to_t4_converter.py`](diffhunk://#diff-62be1a85945bd3f154e4f5fab6110b0c100c0ad712dd83c0b675a4875f4190c3L178-R259): Added `_process_annotations_for_file` method to manage parallel processing of annotations using `ProcessPoolExecutor`.