### PR TITLE
feat(deepen): add get annotation status script

### DIFF
--- a/perception_dataset/deepen/get_annotation_status.py
+++ b/perception_dataset/deepen/get_annotation_status.py
@@ -1,0 +1,43 @@
+import argparse
+from datetime import datetime
+import yaml
+
+from perception_dataset.utils.logger import configure_logger
+from perception_dataset.deepen.import_labels import AnnotationNotFoundException
+from perception_dataset.deepen.import_labels import get_dataset_status
+logger = configure_logger(modname=__name__)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="config/import_labels.yaml",
+    )
+    args = parser.parse_args()
+
+    with open(args.config) as f:
+        config = yaml.safe_load(f)
+
+    dataset_id_dict = config["conversion"]["dataset_ids"]
+
+    date = datetime.now().strftime("%Y-%m-%d")
+    log_file = f"annotation_status_{date}.log"
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    for dataset_name, dataset_id in dataset_id_dict.items():
+        status_msg = ""
+        try:
+            status = get_dataset_status(dataset_id)
+            if status == "done":
+                status_msg = "Done"
+            elif status == "ready":
+                status_msg = "Under Review"
+            else:
+                status_msg = status
+        except AnnotationNotFoundException:
+            status_msg = "Error"
+
+        with open(log_file, "a") as log:
+            log.write(f"{status_msg}\n")
+            # log.write(f"{timestamp}, {dataset_name}, {dataset_id}, {status}\n")

--- a/perception_dataset/deepen/get_annotation_status.py
+++ b/perception_dataset/deepen/get_annotation_status.py
@@ -1,10 +1,11 @@
 import argparse
 from datetime import datetime
+
 import yaml
 
+from perception_dataset.deepen.import_labels import AnnotationNotFoundException, get_dataset_status
 from perception_dataset.utils.logger import configure_logger
-from perception_dataset.deepen.import_labels import AnnotationNotFoundException
-from perception_dataset.deepen.import_labels import get_dataset_status
+
 logger = configure_logger(modname=__name__)
 
 

--- a/perception_dataset/deepen/import_labels.py
+++ b/perception_dataset/deepen/import_labels.py
@@ -35,7 +35,9 @@ class DeepenAccessException(Exception):
 
 
 class AnnotationNotFoundException(Exception):
-    pass
+    def __init__(self, dataset_id: str, *args: Any) -> None:
+        self.dataset_id = dataset_id
+        super().__init__(f"Annotation not found for dataset_id: {dataset_id}")
 
 
 def mark_as_done(dataset_id: str) -> None:
@@ -61,8 +63,8 @@ def get_dataset_status(dataset_id: str) -> str:
     try:
         response = requests.get(url, headers=headers)
         response.raise_for_status()
-    except requests.exceptions.RequestException as e:
-        raise SystemExit(e)
+    except requests.exceptions.RequestException:
+        raise AnnotationNotFoundException(dataset_id)
 
     return response.json()["current_stage_status"]
 


### PR DESCRIPTION
This pull request includes several changes to the `perception_dataset` module, focusing on adding a new script for fetching annotation statuses and improving exception handling in the `import_labels` module. The most important changes include the addition of a new script to get annotation statuses, the enhancement of the `AnnotationNotFoundException` class, and the modification of the `get_dataset_status` function to raise the custom exception.

### New script for fetching annotation statuses:

* [`perception_dataset/deepen/get_annotation_status.py`](diffhunk://#diff-e9db2a76079a9a304d4e11902df7b44da9bf736b8ee2890878494a6ee2bec5f5R1-R43): Added a new script to fetch and log the status of datasets from a configuration file. This script uses `argparse` for command-line arguments, `yaml` for configuration file parsing, and logs the status of each dataset.

### Exception handling improvements:

* [`perception_dataset/deepen/import_labels.py`](diffhunk://#diff-d028bd727dcdfa2a4698c41bd92978833877e991e21dd6bb409844150488ccd8L38-R40): Enhanced the `AnnotationNotFoundException` class to include the `dataset_id` in the exception message.
* [`perception_dataset/deepen/import_labels.py`](diffhunk://#diff-d028bd727dcdfa2a4698c41bd92978833877e991e21dd6bb409844150488ccd8L64-R67): Modified the `get_dataset_status` function to raise `AnnotationNotFoundException` instead of a generic `SystemExit` when a request fails.