### PR TITLE
fix(fastlabel/download_annotations): remove duplicated config, remove debug output

### DIFF
--- a/config/download_fastlabel_annotations.yaml
+++ b/config/download_fastlabel_annotations.yaml
@@ -8,9 +8,6 @@ conversion:
     - 202405-license-plate-person-head-bbox
     - 202405-traffic-light-recognition
     - 3d-lidar-bbox
-    - 3d-lidar-bbox
-    - 3d-lidar-bbox
-    - 3d-lidar-bbox
     - panoptic-segmentation
     - traffic-light-recognition
     - license-plate-person-head

--- a/perception_dataset/fastlabel/download_annotations.py
+++ b/perception_dataset/fastlabel/download_annotations.py
@@ -70,7 +70,6 @@ def rename_image_task_name(name: str) -> str:
     if "_CAM_" not in name:
         return name
     base_name, camera_info = name.split("CAM_")
-    print(f"base_name: {base_name}, camera_info: {camera_info}")
     if base_name.count("/") != 1 and base_name.startswith("data"):
         dataset_name = base_name.split("__")[1]
         camera_name, filename = camera_info.split("__")


### PR DESCRIPTION
This pull request includes changes to the configuration file for downloading annotations and a minor cleanup in the Python script for renaming image task names. The most important changes are:

Configuration file updates:

* [`config/download_fastlabel_annotations.yaml`](diffhunk://#diff-c77c95bb689cd7006f97398af78d86ed03a8b82158844dab709e0c6041210157L11-L13): Removed duplicate entries of `3d-lidar-bbox` to clean up the list of tasks.

Code cleanup:

* [`perception_dataset/fastlabel/download_annotations.py`](diffhunk://#diff-8f4c0ad8eae73929e687030b1521a4cf70e53bbaf0bd593dc46c2a4ba8ba0111L73): Removed a debug print statement from the `rename_image_task_name` function to clean up the code.