### PR TITLE
feat(ins_handler): ignore nav message when status is NO-FIX

### DIFF
--- a/perception_dataset/ros2/oxts_msgs/ins_handler.py
+++ b/perception_dataset/ros2/oxts_msgs/ins_handler.py
@@ -11,7 +11,7 @@ from nav_msgs.msg import Odometry
 import numpy as np
 from scipy.interpolate import interp1d
 from scipy.spatial.transform import Rotation, Slerp
-from sensor_msgs.msg import Imu, NavSatFix
+from sensor_msgs.msg import Imu, NavSatFix, NavSatStatus
 from std_msgs.msg import Header
 
 from perception_dataset.rosbag2.rosbag2_reader import Rosbag2Reader
@@ -452,6 +452,8 @@ class INSHandler:
         timestamps = []
         geo_coordinates: List[Tuple[float, ...]] = []
         for msg in observed:
+            if msg.status.status == NavSatStatus.STATUS_NO_FIX:
+                continue
             timestamps.append(stamp_to_unix_timestamp(msg.header.stamp))
             geo_coordinates.append((msg.latitude, msg.longitude, msg.altitude))
 


### PR DESCRIPTION
This pull request includes changes to the `perception_dataset/ros2/oxts_msgs/ins_handler.py` file to enhance the handling of navigation satellite fixes. The most important changes include importing the `NavSatStatus` message and updating the `interpolate_nav_sat_fixes` function to skip messages with a status indicating no fix.

Enhancements to navigation satellite fix handling:

* [`perception_dataset/ros2/oxts_msgs/ins_handler.py`](diffhunk://#diff-1f82a19385f01e669d0d1ab81c9e64c88406d002fc653659516595786df615acL14-R14): Added import for `NavSatStatus` from `sensor_msgs.msg`.
* [`perception_dataset/ros2/oxts_msgs/ins_handler.py`](diffhunk://#diff-1f82a19385f01e669d0d1ab81c9e64c88406d002fc653659516595786df615acR455-R456): Updated `interpolate_nav_sat_fixes` function to skip messages where `msg.status.status` equals `NavSatStatus.STATUS_NO_FIX`.