### PR TITLE
ci: bump versions of actions for upload/download artifacts to the latest

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -27,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload data for build-and-test
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: test-data
           path: tests/data
@@ -55,7 +55,7 @@ jobs:
             ros-${ROS_DISTRO}-radar-msgs unzip tree
 
       - name: Download test data
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: test-data
           path: tests/data


### PR DESCRIPTION
## Description

<!-- Describe the changes -->

This PR fixes CI failed with duplicated error of upload/download artifact actions by bumping their versions to the latest.

![Screenshot from 2025-01-31 18-40-45](https://github.com/user-attachments/assets/0dea0a50-3862-48e9-9774-6f4283a7889e)

![Screenshot from 2025-01-31 18-41-12](https://github.com/user-attachments/assets/0b9539a2-4f50-4a1a-a9fc-3409ec59a552)

## How to review

<!-- Describe the review procedure -->

## How to test

### test data

<!-- Describe test data -->

### test command

<!-- Describe how to test this PR. -->

```bash

```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
