### PR TITLE
ci: update upload- and download-artifacts actions version

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -27,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload data for build-and-test
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-data
           path: tests/data
@@ -55,7 +55,7 @@ jobs:
             ros-${ROS_DISTRO}-radar-msgs unzip tree
 
       - name: Download test data
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-data
           path: tests/data


### PR DESCRIPTION
## Description
v3 is deprecated
- https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

<!-- Describe the changes -->

## How to review
See if the GitHub Actions passes
<!-- Describe the review procedure -->

## How to test
None

## Reference

None
<!-- Please write external reference if any. -->

## Notes for reviewer
None
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
