### PR TITLE
fix: update segmentation mask shape to (h, w) order

### DIFF
--- a/perception_dataset/t4_dataset/annotation_files_generator.py
+++ b/perception_dataset/t4_dataset/annotation_files_generator.py
@@ -126,10 +126,10 @@ class AnnotationFilesGenerator:
                         {frame_index: sample_nuim["token"]}
                     )
 
-                    wid_hgt = (sample_nuim["width"], sample_nuim["height"])
-                    if wid_hgt != prev_wid_hgt:
-                        prev_wid_hgt = wid_hgt
-                        object_mask = np.zeros(wid_hgt, dtype=np.uint8)
+                    hgt_wid = (sample_nuim["height"], sample_nuim["width"])
+                    if hgt_wid != prev_wid_hgt:
+                        prev_wid_hgt = hgt_wid
+                        object_mask = np.zeros(hgt_wid, dtype=np.uint8)
                         object_mask = cocomask.encode(np.asfortranarray(object_mask))
                         object_mask["counts"] = base64.b64encode(object_mask["counts"]).decode(
                             "ascii"
@@ -338,7 +338,7 @@ class AnnotationFilesGenerator:
     def _clip_bbox(self, bbox: List[float], mask: Dict[str, Any]) -> List[float]:
         """Clip the bbox to the image size."""
         try:
-            width, height = mask["size"]
+            height, width = mask["size"]
             bbox[0] = max(0, bbox[0])
             bbox[1] = max(0, bbox[1])
             bbox[2] = min(width, bbox[2])


### PR DESCRIPTION
## Description

<!-- Describe the changes -->

This PR fixes segmentation mask from (w, h) to (h, w) order.
Related to [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C07J0EUNPCH/p1738281602432569).

## How to review

<!-- Describe the review procedure -->

## How to test

### test data

<!-- Describe test data -->

### test command

<!-- Describe how to test this PR. -->

```bash

```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
