### PR TITLE
feat: raise exception option in rosbag2_to_non_annotated_t4

### DIFF
--- a/perception_dataset/rosbag2/converter_params.py
+++ b/perception_dataset/rosbag2/converter_params.py
@@ -22,6 +22,7 @@ class Rosbag2ConverterParams(BaseModel):
     gt_label_base: str = ""  # path to the gt labels directory
     overwrite_mode: bool = False
     without_compress: bool = False
+    raise_exception: bool = False
     workers_number: int = 1
     with_gt_label: bool = False  # whether to use gt labels
     scene_description: str = ""  # scene description

--- a/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
@@ -102,6 +102,8 @@ class Rosbag2ToNonAnnotatedT4Converter(AbstractConverter):
                 bag_converter.convert()
             except Exception as e:
                 logger.error(f"Error occurred during conversion: {e}")
+                if self._params.raise_exception:
+                    raise e
                 continue
             logger.info(f"Conversion of {bag_dir} is completed")
             print(


### PR DESCRIPTION
## Description

I'm integrating Rosbag2ToNonAnnotatedT4Converter to our system on cloud, and the system must show why conversions fail to our users.
Rosbag2ToNonAnnotatedT4Converter does not raise any exepction when it failed.
I added raise_exception option to Rosbag2ToNonAnnotatedT4Converter. if it is true, Rosbag2ToNonAnnotatedT4Converter can raise a exception in conversions.

## How to review

Rosbag2ConverterParams is common params for various converters. 
As of right now, some converters raise a exception, and some raise no exception.
How can I change other converters?

## How to test

I develops on Mac, so I can't run ros2 local.
I run test on data search annotation pipeline. Should I shrare it's result?
Or should I add test codes?

<!-- Describe test data -->

### test command

<!-- Describe how to test this PR. -->

```bash

```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
