### PR TITLE
fix: receive token and camera info in case of sensor is camera

### DIFF
--- a/perception_dataset/rosbag2/rosbag2_to_annotated_t4_tlr_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_annotated_t4_tlr_converter.py
@@ -151,7 +151,8 @@ class _Rosbag2ToAnnotatedT4TlrConverter(_Rosbag2ToT4Converter):
 
         # Get calibrated sensor token
         start_time_in_time = rosbag2_utils.unix_timestamp_to_stamp(start_timestamp)
-        calibrated_sensor_token = self._generate_calibrated_sensor(
+        # For camera: (calibrated_sensor_token, camera_info)
+        calibrated_sensor_token, _ = self._generate_calibrated_sensor(
             sensor_channel, start_time_in_time, topic
         )
 


### PR DESCRIPTION
## Description

<!-- Describe the changes -->

This PR fixes a bag related to the return value of the function called `self._generate_calibrated_sensor(...)`.
This function returns `calirabted_sensor_token` and `camera_info` in the case of sensor modality is camera.

This PR fixes bug by unpacking return value explicitly.

## How to review

<!-- Describe the review procedure -->

## How to test

### test data

<!-- Describe test data -->

### test command

<!-- Describe how to test this PR. -->

```bash

```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
