### PR TITLE
chore(rosbag2_to_t4): add a conversion config for planning control team

### DIFF
--- a/config/rosbag2_to_t4/convert_rosbag2_to_planning_control_evaluation.yaml
+++ b/config/rosbag2_to_t4/convert_rosbag2_to_planning_control_evaluation.yaml
@@ -1,6 +1,6 @@
 task: convert_rosbag2_to_localization_evaluation # P&C use the same convertor as localization_evaluation, so here we simply use localization_evaluation
 description:
-  scene: ["planning_control_evaluation", "dummy_pcd"] 
+  scene: ["planning_control_evaluation", "dummy_pcd"]
 conversion:
   make_t4_dataset_dir: false # If true, the output directory includes t4_dataset directory (such as "scene_dir"/t4_dataset/data|annotation). If false, "scene_dir"/data|annotation.
   overwrite_mode: false

--- a/config/rosbag2_to_t4/convert_rosbag2_to_planning_control_evaluation.yaml
+++ b/config/rosbag2_to_t4/convert_rosbag2_to_planning_control_evaluation.yaml
@@ -1,0 +1,10 @@
+task: convert_rosbag2_to_localization_evaluation # P&C use the same convertor as localization_evaluation, so here we simply use localization_evaluation
+description:
+  scene: ["planning_control_evaluation", "dummy_pcd"] 
+conversion:
+  make_t4_dataset_dir: false # If true, the output directory includes t4_dataset directory (such as "scene_dir"/t4_dataset/data|annotation). If false, "scene_dir"/data|annotation.
+  overwrite_mode: false
+  input_base: ./data/rosbag2  # Input directory containing raw Rosbag2 files
+  output_base: ./data/planning_control_evaluation_t4_format  # Output directory for T4 format data
+  skip_timestamp: 1.0  # Skip data points at intervals of 1.0 seconds
+  num_load_frames: 0  # Number of frames to load; 0 means load all frames


### PR DESCRIPTION
## Description

This PR adds a conversion config for the planning control team to generate the t4 dataset used for driving log replayer test.
It uses the same converter as localization_evaluation.

## How to review

<!-- Describe the review procedure -->

## How to test

### test data

<!-- Describe test data -->

### test command

<!-- Describe how to test this PR. -->

```bash

```

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
