### PR TITLE
fix: INS rotation correction logic to use proper Euler transformation

### DIFF
--- a/perception_dataset/ros2/oxts_msgs/ins_handler.py
+++ b/perception_dataset/ros2/oxts_msgs/ins_handler.py
@@ -382,12 +382,10 @@ class INSHandler:
             if True:
                 # TODO: tentative correction. If the INS coordinates are fixed, remove this correction.
                 r_current = Rotation.from_quat(current_rotation)
-                yaw_correction = Rotation.from_euler('z', -np.pi/2)
-                roll_correction = Rotation.from_euler('x', np.pi)
-                r_new = roll_correction * yaw_correction * r_current
-                yaw, pitch, roll = r_new.as_euler('zyx')
-                yaw = -yaw
-                r_new = Rotation.from_euler('z', yaw) * Rotation.from_euler('y', pitch) * Rotation.from_euler('x', roll)
+                roll, pitch, yaw = r_current.as_euler("xyz")
+                yaw = yaw - np.pi/2
+                roll = roll + np.pi
+                r_new = Rotation.from_euler("z", yaw) * Rotation.from_euler("y", pitch) * Rotation.from_euler("x", roll)
                 current_rotation = r_new.as_quat()
                 current_twist.angular.z = -current_twist.angular.z
                 current_acceleration[1] = -current_acceleration[1]

--- a/perception_dataset/ros2/oxts_msgs/ins_handler.py
+++ b/perception_dataset/ros2/oxts_msgs/ins_handler.py
@@ -368,7 +368,6 @@ class INSHandler:
                 current_pose.orientation.z,
                 current_pose.orientation.w,
             ]
-
             current_twist = odometry.twist.twist
 
             # acceleration from imu
@@ -379,6 +378,19 @@ class INSHandler:
                 imu.linear_acceleration.y,
                 imu.linear_acceleration.z,
             ]
+
+            if True:
+                # TODO: tentative correction. If the INS coordinates are fixed, remove this correction.
+                r_current = Rotation.from_quat(current_rotation)
+                yaw_correction = Rotation.from_euler('z', -np.pi/2)
+                roll_correction = Rotation.from_euler('x', np.pi)
+                r_new = roll_correction * yaw_correction * r_current
+                yaw, pitch, roll = r_new.as_euler('zyx')
+                yaw = -yaw
+                r_new = Rotation.from_euler('z', yaw) * Rotation.from_euler('y', pitch) * Rotation.from_euler('x', roll)
+                current_rotation = r_new.as_quat()
+                current_twist.angular.z = -current_twist.angular.z
+                current_acceleration[1] = -current_acceleration[1]
 
             ego_state = EgoState(
                 header=odometry.header,

--- a/perception_dataset/ros2/oxts_msgs/ins_handler.py
+++ b/perception_dataset/ros2/oxts_msgs/ins_handler.py
@@ -383,9 +383,13 @@ class INSHandler:
                 # TODO: tentative correction. If the INS coordinates are fixed, remove this correction.
                 r_current = Rotation.from_quat(current_rotation)
                 roll, pitch, yaw = r_current.as_euler("xyz")
-                yaw = yaw - np.pi/2
+                yaw = yaw - np.pi / 2
                 roll = roll + np.pi
-                r_new = Rotation.from_euler("z", yaw) * Rotation.from_euler("y", pitch) * Rotation.from_euler("x", roll)
+                r_new = (
+                    Rotation.from_euler("z", yaw)
+                    * Rotation.from_euler("y", pitch)
+                    * Rotation.from_euler("x", roll)
+                )
                 current_rotation = r_new.as_quat()
                 current_twist.angular.z = -current_twist.angular.z
                 current_acceleration[1] = -current_acceleration[1]

--- a/perception_dataset/ros2/oxts_msgs/ins_handler.py
+++ b/perception_dataset/ros2/oxts_msgs/ins_handler.py
@@ -368,6 +368,7 @@ class INSHandler:
                 current_pose.orientation.z,
                 current_pose.orientation.w,
             ]
+
             current_twist = odometry.twist.twist
 
             # acceleration from imu


### PR DESCRIPTION
**Fix INS Rotation Correction in `INSHandler`**

This PR updates the temporary rotation correction logic in `INSHandler` to properly adjust the INS output.

**Changes:**
- Apply a tentative correction to roll and yaw angles to compensate for incorrect INS driver output
- Convert current rotation from quaternion to Euler angles (`xyz` order)
- Adjust yaw (`-π/2`) and roll (`+π`) to align with the expected coordinate frame
- Update `current_rotation` with the corrected transformation
- Invert `current_twist.angular.z` and `current_acceleration[1]` to match the correct orientation

**Note:**
This is a temporary fix. If the INS driver is updated to provide correct outputs, this correction should be removed.
