### PR TITLE
feat: support top left and right center cameras facing directly sideways

### DIFF
--- a/perception_dataset/constants.py
+++ b/perception_dataset/constants.py
@@ -16,6 +16,14 @@ class SENSOR_MODALITY_ENUM(Enum):
 
 
 class SENSOR_ENUM(Enum):
+    CAM_TOP_LEFT_CENTER = {
+        "channel": "CAM_TOP_LEFT_CENTER",
+        "modality": SENSOR_MODALITY_ENUM.CAMERA.value,
+    }
+    CAM_TOP_RIGHT_CENTER = {
+        "channel": "CAM_TOP_RIGHT_CENTER",
+        "modality": SENSOR_MODALITY_ENUM.CAMERA.value,
+    }
     CAM_BACK_LEFT = {
         "channel": "CAM_BACK_LEFT",
         "modality": SENSOR_MODALITY_ENUM.CAMERA.value,


### PR DESCRIPTION
## Description

The current cameras positions are not enough for larger vehicles like buses with 11+ cameras for certain positions.
This PR Adds two more camera positions for longer-form vehicles like buses that have top cameras located along of the length of the vehicle, and facing sideways.