### PR TITLE
chore: bump version from 1.0.22 to 1.0.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "perception-dataset"
-version = "1.0.22"
+version = "1.0.23"
 description = "TIER IV Perception dataset has modules to convert dataset from rosbag to t4_dataset"
 authors = [
     "Yusuke Muramatsu <yusuke.muramatsu@tier4.jp>",


### PR DESCRIPTION
This pull request includes a version bump for the `perception-dataset` package in the `pyproject.toml` file. The version has been updated from `1.0.22` to `1.0.23`.