### PR TITLE
ci: ROS GPG key error 

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -49,9 +49,8 @@ jobs:
 
       - name: ROS signing key workaround
         run: |
-          ls -lha /etc/apt/sources.list.d
-          cat /usr/share/ros-apt-source/ros2.sources
-          sudo rm /etc/apt/sources.list.d/ros2.list
+          sudo rm /usr/share/ros-apt-source/ros2.sources
+          ls -lha  /usr/share/keyrings/
           sudo rm /usr/share/keyrings/ros2-archive-keyring.gpg
           sudo apt update && sudo apt install -y curl ca-certificates
           export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -49,8 +49,9 @@ jobs:
 
       - name: ROS signing key workaround
         run: |
-          sudo rm /etc/apt/sources.list.d/ros2-latest.list
-          sudo rm /usr/share/keyrings/ros2-latest-archive-keyring.gpg
+          ls -lha /etc/apt/sources.list.d
+          sudo rm /etc/apt/sources.list.d/ros2.list
+          sudo rm /usr/share/keyrings/ros2-archive-keyring.gpg
           sudo apt update && sudo apt install -y curl ca-certificates
           export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
               curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -47,6 +47,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: ROS signing key workaround
+        run: |
+          sudo rm /etc/apt/sources.list.d/ros2-latest.list
+          sudo rm /usr/share/keyrings/ros2-latest-archive-keyring.gpg
+          sudo apt update && sudo apt install -y curl ca-certificates
+          export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
+              curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+              && sudo apt-get update \
+              && sudo apt-get install /tmp/ros2-apt-source.deb \
+              && sudo rm -f /tmp/ros2-apt-source.deb
+
       - name: Install dependencies
         run: |
           apt update -yqq

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -50,6 +50,7 @@ jobs:
       - name: ROS signing key workaround
         run: |
           ls -lha /etc/apt/sources.list.d
+          cat /usr/share/ros-apt-source/ros2.sources
           sudo rm /etc/apt/sources.list.d/ros2.list
           sudo rm /usr/share/keyrings/ros2-archive-keyring.gpg
           sudo apt update && sudo apt install -y curl ca-certificates

--- a/config/convert_fastlabel_to_t4_#7_0822.yaml
+++ b/config/convert_fastlabel_to_t4_#7_0822.yaml
@@ -1,0 +1,24 @@
+task: convert_fastlabel_to_t4
+description:
+  visibility:
+    full: "No occlusion of the object."
+    most: "Object is occluded, but by less than 50%."
+    partial: "The object is occluded by more than 50% (but not completely)."
+    none: "The object is 90-100% occluded and no points/pixels are visible in the label."
+  camera_index:
+    CAM_FRONT_NARROW: 0
+    CAM_FRONT_WIDE: 1
+    CAM_FRONT_RIGHT: 2
+    CAM_BACK_RIGHT: 3
+    CAM_BACK_NARROW: 4
+    CAM_BACK_WIDE: 5
+    CAM_BACK_LEFT: 6
+    CAM_FRONT_LEFT: 7
+
+conversion:
+  make_t4_dataset_dir: false # If true, the output directory includes t4_dataset directory (such as "scene_dir"/t4_dataset/data|annotation). If false, "scene_dir"/data|annotation.
+  input_base: /mnt/fs_nas_4/comlops_dataset/20240822
+  input_anno_base: /mnt/NVME_RAID0_36TB/tmp/tier4_perception_dataset/label_data_2409-2502/pcd_annotation
+  output_base: /mnt/HDD_RAID0_120TB/comlops_dataset_conversion/fastlabel_with_3d-annotation/20241224_#7_240822
+  input_bag_base: null  #optional
+  topic_list: null  #necessary if input_bag_base is not null


### PR DESCRIPTION
This pull request introduces a workaround to address an issue with the ROS signing key in the GitHub Actions workflow. The change ensures that the correct ROS APT source is installed during the build process.

### Workflow Updates:

* [`.github/workflows/build-and-test.yaml`](diffhunk://#diff-a551b322da0f9fe92abd1ec41e43c58dc5d138c0000430395e66f0c581387cd2R50-R60): Added a step to remove outdated ROS signing key files and reconfigure the ROS APT source using the latest release from the `ros-apt-source` repository. This includes downloading and installing the appropriate `.deb` package for the system's version codename.