### PR TITLE
feat: add drs 10hz conversion config, fix camera_scan_period_sec default value params

### DIFF
--- a/config/convert_rosbag2_to_non_annotated_t4_drs_10hz.yaml
+++ b/config/convert_rosbag2_to_non_annotated_t4_drs_10hz.yaml
@@ -15,33 +15,32 @@ conversion:
   # The following configuration is generally not modified unless there are changes to the vehicle sensor configuration.
   max_camera_jitter_sec: 0.005
   lidar_latency_sec: 0.005
-  system_scan_period_sec: 0.10  # LiDAR scan period
-  camera_scan_period_sec: 0.05  # Camera scan period
+  system_scan_period_sec: 0.05
   lidar_sensor:
     topic: /sensing/lidar/concatenated/pointcloud
     channel: LIDAR_CONCAT
   camera_sensors:
     - topic: /sensing/camera/camera0/image_raw/compressed
       channel: CAM_FRONT_NARROW
-      delay_msec: 16.0
+      delay_msec: -58.5
     - topic: /sensing/camera/camera1/image_raw/compressed
       channel: CAM_FRONT_WIDE
-      delay_msec: 16.0
+      delay_msec: -58.5
     - topic: /sensing/camera/camera2/image_raw/compressed
       channel: CAM_FRONT_RIGHT
-      delay_msec: -9.0
+      delay_msec: -55.0
     - topic: /sensing/camera/camera3/image_raw/compressed
       channel: CAM_BACK_RIGHT
-      delay_msec: -59.0
+      delay_msec: -5.0
     - topic: /sensing/camera/camera4/image_raw/compressed
       channel: CAM_BACK_NARROW
-      delay_msec: -34.0
+      delay_msec: -58.5
     - topic: /sensing/camera/camera5/image_raw/compressed
       channel: CAM_BACK_WIDE
-      delay_msec: -84.0
+      delay_msec: -58.5
     - topic: /sensing/camera/camera6/image_raw/compressed
       channel: CAM_BACK_LEFT
-      delay_msec: -59.0
+      delay_msec: -5.0
     - topic: /sensing/camera/camera7/image_raw/compressed
       channel: CAM_FRONT_LEFT
-      delay_msec: -59.0
+      delay_msec: -55.0

--- a/perception_dataset/rosbag2/converter_params.py
+++ b/perception_dataset/rosbag2/converter_params.py
@@ -86,6 +86,8 @@ class Rosbag2ConverterParams(BaseModel):
     def __init__(self, **args):
         if "scene_description" in args and isinstance(args["scene_description"], list):
             args["scene_description"] = ", ".join(args["scene_description"])
+        if not "camera_scan_period_sec" in args and "system_scan_period_sec" in args:
+            args["camera_scan_period_sec"] = args["system_scan_period_sec"]
         if "topic_list" in args and isinstance(args["topic_list"], str):
             with open(args["topic_list"]) as f:
                 args["topic_list"] = yaml.safe_load(f)

--- a/perception_dataset/utils/misc.py
+++ b/perception_dataset/utils/misc.py
@@ -132,7 +132,7 @@ def get_lidar_camera_frame_info_async(
             A list where each entry represents a matched or unmatched frame pair:
             - image_index: index of the image frame (or None if missing)
             - lidar_index: index of the LiDAR frame (or None if missing)
-            - dummy_timestamp: an adjusted timestamp when either frame is missing; None if both are present
+            - dummy_timestamp: an adjusted timestamp for the image frame when it is missing; None if the image is present.
     """
     synced_frame_info_list: List[Tuple[Optional[int], Optional[int], Optional[float]]] = []
 


### PR DESCRIPTION
This pull request introduces updates to configuration files and the `Rosbag2ConverterParams` class to enhance the handling of sensor data and streamline parameter initialization. The changes include adjustments to camera sensor configurations, the addition of a new configuration file, and improved initialization logic for scan periods.

### Configuration Updates:

* **New Configuration File:**
  Added `config/convert_rosbag2_to_non_annotated_t4_drs_10hz.yaml`

### Code Logic Enhancement:

* **Automatic Camera Scan Period Initialization:**
  Modified the `Rosbag2ConverterParams` class in `perception_dataset/rosbag2/converter_params.py` to automatically set `camera_scan_period_sec` to `system_scan_period_sec` if the former is not provided, simplifying parameter setup.