### PR TITLE
fix(convert_rosbag2_to_non_annotated_t4): index alignment for image-LiDAR synchronization and improve robustness of timestamp pairing

### DIFF
--- a/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
@@ -907,7 +907,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
         return sample_data_token_list
 
     def _make_file_index_func(self):
-        last_synced_lidar_index = None
+        last_synced_lidar_index = 0
         suffix = 0
 
         def _get_file_index(image_index: int, lidar_index: int) -> str:

--- a/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
@@ -794,7 +794,9 @@ class _Rosbag2ToNonAnnotatedT4Converter:
             # Save image
             sample_data_token_list: List[str] = []
             image_index_counter = -1
-            first_synced_image_index = synced_frame_info_list[0][0] if synced_frame_info_list else 0
+            first_synced_image_index = (
+                synced_frame_info_list[0][0] if synced_frame_info_list else 0
+            )
             image_generator = self._bag_reader.read_messages(
                 topics=[topic], start_time=start_time_in_time
             )
@@ -827,7 +829,11 @@ class _Rosbag2ToNonAnnotatedT4Converter:
                     while image_index_counter < image_index:
                         image_msg = next(image_generator)
                         image_index_counter += 1
-                    file_index = lidar_frame_index if self._camera_lidar_sync_mode else image_index - first_synced_image_index
+                    file_index = (
+                        lidar_frame_index
+                        if self._camera_lidar_sync_mode
+                        else image_index - first_synced_image_index
+                    )
                     sample_data_token = self._generate_image_data(
                         image_msg,
                         rosbag2_utils.stamp_to_unix_timestamp(image_msg.header.stamp),

--- a/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
@@ -794,6 +794,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
             # Save image
             sample_data_token_list: List[str] = []
             image_index_counter = -1
+            first_synced_image_index = synced_frame_info_list[0][0] if synced_frame_info_list else 0
             image_generator = self._bag_reader.read_messages(
                 topics=[topic], start_time=start_time_in_time
             )
@@ -826,8 +827,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
                     while image_index_counter < image_index:
                         image_msg = next(image_generator)
                         image_index_counter += 1
-
-                    file_index = lidar_frame_index if self._camera_lidar_sync_mode else image_index
+                    file_index = lidar_frame_index if self._camera_lidar_sync_mode else image_index - first_synced_image_index
                     sample_data_token = self._generate_image_data(
                         image_msg,
                         rosbag2_utils.stamp_to_unix_timestamp(image_msg.header.stamp),

--- a/perception_dataset/utils/misc.py
+++ b/perception_dataset/utils/misc.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 from perception_dataset.constants import T4_FORMAT_DIRECTORY_NAME
 
@@ -12,11 +12,13 @@ def nusc_timestamp_to_unix_timestamp(timestamp: int) -> float:
     return float(timestamp) * 1e-6
 
 
-def get_sample_data_filename(sensor_channel: str, frame_index: int, fileformat: str):
+def get_sample_data_filename(sensor_channel: str, file_name: Union[int, str], fileformat: str):
+    if isinstance(file_name, int):
+        file_name = f"{file_name:05d}"
     filename = os.path.join(
         T4_FORMAT_DIRECTORY_NAME.DATA.value,
         sensor_channel,
-        f"{frame_index:05}.{fileformat}",
+        f"{file_name}.{fileformat}",
     )
     return filename
 

--- a/perception_dataset/utils/misc.py
+++ b/perception_dataset/utils/misc.py
@@ -194,9 +194,9 @@ def get_lidar_camera_frame_info_async(
             lidar_index += 1
             first_frame_loaded = True
 
-        if image_index % msg_display_interval == 0:
+        if len(synced_frame_info_list) % msg_display_interval == 1:
             print(
-                f"frame{lidar_index}, stamp = {image_timestamp}, diff cam - lidar = {image_timestamp - lidar_timestamp:0.3f} sec"
+                f"frame{synced_frame_info_list[-1][1]}, stamp = {image_timestamp}, diff cam - lidar = {image_timestamp - lidar_timestamp:0.3f} sec"
             )
 
     return synced_frame_info_list

--- a/perception_dataset/utils/misc.py
+++ b/perception_dataset/utils/misc.py
@@ -138,29 +138,34 @@ def get_lidar_camera_frame_info_async(
 
     lidar_index = 0
     image_index = 0
+    image_index_offset = 0
     lidar_load_completed = False
     image_load_completed = False
     first_frame_loaded = False
     half_camera_period_with_jitter = camera_scan_period / 2 + max_camera_jitter
 
     while lidar_index < num_load_lidar_frames or image_index < num_load_image_frames:
-        if lidar_index < num_load_lidar_frames:
+        if lidar_index < num_load_lidar_frames and lidar_index < len(lidar_timestamp_list):
             lidar_timestamp = lidar_timestamp_list[lidar_index]
         else:
             lidar_load_completed = True
             lidar_timestamp = lidar_timestamp_list[-1]
 
-        if image_index < num_load_image_frames:
+        if image_index < num_load_image_frames and image_index < len(image_timestamp_list):
             image_timestamp = image_timestamp_list[image_index]
         else:
             image_load_completed = True
             image_timestamp = image_timestamp_list[-1]
 
+        if lidar_load_completed and image_load_completed:
+            print("All frames loaded; exiting loop")
+            break
+
         adjusted_image_timestamp = image_timestamp - lidar_to_camera_latency
 
         if lidar_load_completed:
             # All LiDAR frames are loaded
-            synced_frame_info_list.append((image_index, None, None))
+            synced_frame_info_list.append((image_index + image_index_offset, None, None))
             image_index += 1
         elif image_load_completed:
             # All image frames are loaded
@@ -170,11 +175,12 @@ def get_lidar_camera_frame_info_async(
         elif adjusted_image_timestamp < lidar_timestamp - half_camera_period_with_jitter:
             # Image timestamp is too early; assume LiDAR frame is missing
             if first_frame_loaded:
-                synced_frame_info_list.append((image_index, None, None))
+                synced_frame_info_list.append((image_index + image_index_offset, None, None))
                 image_index += 1
             else:
                 # Drop current image timestamp and try next to find the first aligned frame
                 image_timestamp_list = image_timestamp_list[1:]
+                image_index_offset += 1
         elif adjusted_image_timestamp > lidar_timestamp + half_camera_period_with_jitter:
             # LiDAR timestamp is too early; assume image frame is missing
             dummy_timestamp = lidar_timestamp + lidar_to_camera_latency
@@ -183,7 +189,7 @@ def get_lidar_camera_frame_info_async(
             first_frame_loaded = True
         else:
             # Both image and LiDAR frames are available and matched
-            synced_frame_info_list.append((image_index, lidar_index, None))
+            synced_frame_info_list.append((image_index + image_index_offset, lidar_index, None))
             image_index += 1
             lidar_index += 1
             first_frame_loaded = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "perception-dataset"
-version = "1.0.23"
+version = "1.0.24"
 description = "TIER IV Perception dataset has modules to convert dataset from rosbag to t4_dataset"
 authors = [
     "Yusuke Muramatsu <yusuke.muramatsu@tier4.jp>",

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -300,7 +300,7 @@ def test_camera_20fps_lidar_2frames_10fps_camera_4frames():
     assert result == expected, f"Expected {expected}, but got {result}"
 
 
-def test_first_camera_frame_dropped():
+def test_first_lidar_frame_dropped():
     # Camera: 0.00, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.35
     # 1st and 2nd frames will be removed
     image_ts = [0.00, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.35]

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -293,10 +293,42 @@ def test_camera_20fps_lidar_2frames_10fps_camera_4frames():
     expected = [
         (0, 0, None),  # image 0 ↔ lidar 0
         (1, None, None),  # image 1 unmatched
-        (2, 1, None),  # lidar 1 ↔ image 2
+        (2, 1, None),  # image 2 ↔ lidar 1
         (3, None, None),  # image 3 unmatched
     ]
 
+    assert result == expected, f"Expected {expected}, but got {result}"
+
+
+def test_first_camera_frame_dropped():
+    # Camera: 0.00, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.35
+    # 1st and 2nd frames will be removed
+    image_ts = [0.00, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.35]
+    # LiDAR: 0.10, 0.20
+    lidar_ts = [0.10, 0.20]
+
+    result = misc_utils.get_lidar_camera_frame_info_async(
+        image_timestamp_list=image_ts,
+        lidar_timestamp_list=lidar_ts,
+        lidar_to_camera_latency=0.0,
+        max_camera_jitter=0.005,
+        camera_scan_period=0.05,
+        num_load_image_frames=100,
+        num_load_lidar_frames=50,
+        msg_display_interval=1,
+    )
+
+    expected = [
+        (2, 0, None),
+        (3, None, None),
+        (4, 1, None),
+        (5, None, None),
+        (6, None, None),
+        (7, None, None),
+    ]
+
+    print(f"image_ts: {image_ts}, lidar_ts: {lidar_ts}")
+    print(f"result: {result}")
     assert result == expected, f"Expected {expected}, but got {result}"
 
 


### PR DESCRIPTION
### Summary
This PR enhances the logic for generating file indices and synchronizing LiDAR and camera frames in asynchronous sensor setups.


### ✨ Enhancements

- Introduced `_make_file_index_func()` to:
  - Dynamically generate file indices depending on camera-LiDAR sync mode.
  - Add suffixes (e.g., `00010-01`) for unmatched camera frames to avoid filename collisions.
- Updated `get_sample_data_filename()` to support both `int` and `str` types for frame indices.
- Improved `get_lidar_camera_frame_info_async()` to:
  - Correctly handle dropped or unmatched initial camera frames.
  - Keep accurate image frame indexing by introducing an offset.
  - Improve debug logging with actual LiDAR frame indices.


### ✅ Tests

- Added `test_first_camera_frame_dropped()` to verify correct indexing when the first camera frames are not matched to LiDAR.
- Updated `test_camera_20fps_lidar_2frames_10fps_camera_4frames()` to reflect refined synchronization behavior.
