### PR TITLE
refactor(label_converter): use dict.get for label conversion fallback

### DIFF
--- a/perception_dataset/utils/label_converter.py
+++ b/perception_dataset/utils/label_converter.py
@@ -22,7 +22,7 @@ class BaseConverter(ABC):
         return label_map
 
     def convert_label(self, label: str) -> str:
-        return self.label_map[label]
+        return self.label_map.get(label, label)
 
 
 class LabelConverter(BaseConverter):


### PR DESCRIPTION
## Overview

- Refactored the label conversion process (`convert_label`) to use `dict.get` for fallback.
- Now, if a label is not found in the mapping, the original label is returned, preventing exceptions.

## Changes

- Updated the `convert_label` method in `label_converter.py` to use `self.label_map.get(label, label)`.
- Improved code readability and robustness.

## Verification

- All existing unit tests pass.
- Confirmed that passing a label not in the mapping returns the original label without raising an exception.
