### PR TITLE
feat: support front/back left and right wide cameras

### DIFF
--- a/perception_dataset/constants.py
+++ b/perception_dataset/constants.py
@@ -28,6 +28,10 @@ class SENSOR_ENUM(Enum):
         "channel": "CAM_BACK_LEFT",
         "modality": SENSOR_MODALITY_ENUM.CAMERA.value,
     }
+    CAM_BACK_LEFT_WIDE = {
+        "channel": "CAM_BACK_LEFT_WIDE",
+        "modality": SENSOR_MODALITY_ENUM.CAMERA.value,
+    }
     CAM_FRONT = {
         "channel": "CAM_FRONT",
         "modality": SENSOR_MODALITY_ENUM.CAMERA.value,
@@ -44,8 +48,16 @@ class SENSOR_ENUM(Enum):
         "channel": "CAM_FRONT_RIGHT",
         "modality": SENSOR_MODALITY_ENUM.CAMERA.value,
     }
+    CAM_FRONT_RIGHT_WIDE = {
+        "channel": "CAM_FRONT_RIGHT_WIDE",
+        "modality": SENSOR_MODALITY_ENUM.CAMERA.value,
+    }
     CAM_BACK_RIGHT = {
         "channel": "CAM_BACK_RIGHT",
+        "modality": SENSOR_MODALITY_ENUM.CAMERA.value,
+    }
+    CAM_BACK_RIGHT_WIDE = {
+        "channel": "CAM_BACK_RIGHT_WIDE",
         "modality": SENSOR_MODALITY_ENUM.CAMERA.value,
     }
     CAM_BACK = {
@@ -62,6 +74,10 @@ class SENSOR_ENUM(Enum):
     }
     CAM_FRONT_LEFT = {
         "channel": "CAM_FRONT_LEFT",
+        "modality": SENSOR_MODALITY_ENUM.CAMERA.value,
+    }
+    CAM_FRONT_LEFT_WIDE = {
+        "channel": "CAM_FRONT_LEFT_WIDE",
         "modality": SENSOR_MODALITY_ENUM.CAMERA.value,
     }
     CAM_TRAFFIC_LIGHT_NEAR = {


### PR DESCRIPTION
## Description
Added 4 new wide-angle camera channel definitions to SENSOR_ENUM:
    - `CAM_FRONT_LEFT_WIDE`
    - `CAM_FRONT_RIGHT_WIDE`
    - `CAM_BACK_LEFT_WIDE`
    - `CAM_BACK_RIGHT_WIDE`

## How to test

### test data
I have downloaded T4 datatset [(ID:cbf88fa3)](cbf88fa3-f9ea-46ba-ad52-75f4e0364e0a) and used the ros bag file under `input_bag` as the input.
I have created the following config file:
```
task: convert_rosbag2_to_non_annotated_t4
description:
  scene: ""
conversion:
  input_base: /home/npc2301030/.webauto/data/data/annotation_dataset/cbf88fa3-f9ea-46ba-ad52-75f4e0364e0a/0/
  output_base: ./data/non_annotated_t4_format
  skip_timestamp: 0.0
  num_load_frames: 0
  start_timestamp_sec: 0.0
  accept_frame_drop: True
  undistort_image: True
  lidar_sensor:
    topic: /sensing/lidar/concatenated/pointcloud
    channel: LIDAR_CONCAT
  camera_sensors:
    - topic: /sensing/camera/camera0/image_raw/compressed
      channel: CAM_FRONT
      delay_msec: 33.34
    - topic: /sensing/camera/camera3/image_raw/compressed
      channel: CAM_FRONT_LEFT
      delay_msec: 19.45
    - topic: /sensing/camera/camera4/image_raw/compressed
      channel: CAM_FRONT_RIGHT
      delay_msec: 47.22
    - topic: /sensing/camera/camera9/image_raw/compressed
      channel: CAM_BACK_LEFT
      delay_msec: -9
    - topic: /sensing/camera/camera10/image_raw/compressed
      channel: CAM_BACK_RIGHT
      delay_msec: 77.78
    - topic: /sensing/camera/camera2/image_raw/compressed
      channel: CAM_TRAFFIC_LIGHT_FAR
      delay_msec: 33.34
    - topic: /sensing/camera/camera1/image_raw/compressed
      channel: CAM_FRONT_WIDE
      delay_msec: 51.34
    - topic: /sensing/camera/camera5/image_raw/compressed
      channel: CAM_FRONT_LEFT_WIDE
      delay_msec: 119
    - topic: /sensing/camera/camera6/image_raw/compressed
      channel: CAM_FRONT_RIGHT_WIDE
      delay_msec: 50.00
    - topic: /sensing/camera/camera7/image_raw/compressed
      channel: CAM_BACK_LEFT_WIDE
      delay_msec: 110.18
    - topic: /sensing/camera/camera8/image_raw/compressed
      channel: CAM_BACK_RIGHT_WIDE
      delay_msec: 92.96
  ignore_no_ego_transform_at_rosbag_beginning: True
```

### test command
```
python3 -m perception_dataset.convert --config config/convert_rosbag2_to_non_annotated_t4_e2e.yaml --without_compress
```

### Result
Output on terminal
```
--------------------------------------------------------------------------------------------------------------------------
log.json: #rows 1
map.json: #rows 1
sensor.json: #rows 12
calibrated_sensor.json: #rows 12
scene.json: #rows 1
sample.json: #rows 593
sample_data.json: #rows 7116
ego_pose.json: #rows 7116
instance.json: #rows 0
sample_annotation.json: #rows 0
category.json: #rows 0
attribute.json: #rows 0
visibility.json: #rows 0
vehicle_state.json: #rows 0
--------------------------------------------------------------------------------------------------------------------------
```
```
for dir in */; do echo -n "$dir: "; find "$dir" -maxdepth 1 -type f | wc -l; done

CAM_BACK_LEFT/: 593
CAM_BACK_LEFT_WIDE/: 593
CAM_BACK_RIGHT/: 593
CAM_BACK_RIGHT_WIDE/: 593
CAM_FRONT/: 593
CAM_FRONT_LEFT/: 593
CAM_FRONT_LEFT_WIDE/: 593
CAM_FRONT_RIGHT/: 593
CAM_FRONT_RIGHT_WIDE/: 593
CAM_FRONT_WIDE/: 593
CAM_TRAFFIC_LIGHT_FAR/: 593
LIDAR_CONCAT/: 593
```
