### PR TITLE
Fix(INS_support): add consistent geolocation, twist and acceleration for gen2 vehicles

### DIFF
--- a/config/convert_rosbag2_to_non_annotated_t4_sample.yaml
+++ b/config/convert_rosbag2_to_non_annotated_t4_sample.yaml
@@ -10,6 +10,12 @@ conversion:
   num_load_frames: 0 # Maximum number of frames to save as t4 data. Set to 0 to automatically set it based on the number of lidar topics.
   accept_frame_drop: False # If true, the conversion will continue even if the LiDAR frame is dropped.
   undistort_image: False # If true, the camera image will be undistorted.
+  # INS settings for adding geolocalization information
+  with_ins: false # whether to use INS messages as a ego state instead of `/tf`
+  ins_topic_mapping: # mappings for j6gen2 and jpntaxigen2
+    imu: /sensing/imu/tamagawa/imu_raw
+    nav_sat_fix: /sensing/gnss/septentrio/nav_sat_fix
+    odometry: /localization/kinematic_state
   # The following configuration is generally not modified unless there are changes to the vehicle sensor configuration.
   max_camera_jitter_sec: 0.005
   lidar_latency_sec: 0.005

--- a/perception_dataset/ros2/oxts_msgs/ins_handler.py
+++ b/perception_dataset/ros2/oxts_msgs/ins_handler.py
@@ -310,7 +310,6 @@ class INSHandler:
         "imu": "/ins/oxts/imu",
         "nav_sat_fix": "/ins/oxts/nav_sat_fix",
         "odometry": "/ins/oxts/odometry",
-        "velocity": "/ins/oxts/velocity",
     }
 
     def __init__(

--- a/perception_dataset/rosbag2/converter_params.py
+++ b/perception_dataset/rosbag2/converter_params.py
@@ -146,7 +146,7 @@ class Rosbag2ConverterParams(BaseModelWithDictAccess):
     generate_frame_every: int = 1  # pick frames out of every this number.
     generate_frame_every_meter: float = 5.0  # pick frames when ego vehicle moves certain meters
 
-    # INS 
+    # INS
     with_ins: bool = False  # whether to convert rosbag with INS topics for localization
     ins_topic_mapping: Optional[Dict[str, str]] = None  # topic mappings for specific vehicles
     with_vehicle_status: bool = False  # whether to convert rosbag with vehicle status

--- a/perception_dataset/rosbag2/converter_params.py
+++ b/perception_dataset/rosbag2/converter_params.py
@@ -146,8 +146,9 @@ class Rosbag2ConverterParams(BaseModelWithDictAccess):
     generate_frame_every: int = 1  # pick frames out of every this number.
     generate_frame_every_meter: float = 5.0  # pick frames when ego vehicle moves certain meters
 
-    # for Co-MLOps
-    with_ins: bool = False  # whether to convert rosbag with INS topics
+    # INS 
+    with_ins: bool = False  # whether to convert rosbag with INS topics for localization
+    ins_topic_mapping: Optional[Dict[str, str]] = None  # topic mappings for specific vehicles
     with_vehicle_status: bool = False  # whether to convert rosbag with vehicle status
 
     def __init__(self, **args):

--- a/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
@@ -61,6 +61,7 @@ from perception_dataset.rosbag2.converter_params import (
 )
 from perception_dataset.rosbag2.rosbag2_reader import Rosbag2Reader
 from perception_dataset.t4_dataset.table_handler import TableHandler
+from perception_dataset.ros2.oxts_msgs.ins_handler import EgoState, INSHandler
 from perception_dataset.utils.logger import configure_logger
 import perception_dataset.utils.misc as misc_utils
 import perception_dataset.utils.rosbag2 as rosbag2_utils
@@ -249,7 +250,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
         self._optional_ins_lookup_warning_logged = False
 
         if self._with_ins:
-            self._ins_handler = self._make_ins_handler(params)
+            self._ins_handler = INSHandler(params.input_bag_path, topic_mapping=params.ins_topic_mapping)
         else:
             self._ins_handler = self._make_optional_ins_handler(params)
 
@@ -262,24 +263,12 @@ class _Rosbag2ToNonAnnotatedT4Converter:
         else:
             self._vehicle_status_handler = None
 
-    def _make_ins_handler(self, params: Rosbag2ConverterParams):
-        from perception_dataset.ros2.oxts_msgs.ins_handler import INSHandler
-
-        if params.ins_topic_mapping is None:
-            return INSHandler(params.input_bag_path)
-        return INSHandler(
-            params.input_bag_path,
-            topic_mapping=params.ins_topic_mapping,
-        )
-
-    def _make_optional_ins_handler(self, params: Rosbag2ConverterParams):
-        from perception_dataset.ros2.oxts_msgs.ins_handler import INSHandler
-
+    def _make_optional_ins_handler(self, params: Rosbag2ConverterParams) -> Optional[INSHandler]:
         topic_mapping = INSHandler.get_topic_mapping(params.ins_topic_mapping)
         missing_topics = [
             topic
             for topic in topic_mapping.values()
-            if self._bag_reader.get_topic_count(topic) == 0
+            if not self._bag_reader.get_topic_count(topic)
         ]
         if missing_topics:
             logger.info(
@@ -289,7 +278,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
             return None
 
         try:
-            return self._make_ins_handler(params)
+            return INSHandler(params.input_bag_path, topic_mapping=params.ins_topic_mapping)
         except Exception as e:
             logger.warning(f"Skipping optional INS ego_pose fields: {e}")
             self._optional_ins_lookup_warning_logged = True
@@ -1231,7 +1220,9 @@ class _Rosbag2ToNonAnnotatedT4Converter:
     def _generate_ego_pose(self, stamp: builtin_interfaces.msg.Time) -> str:
         if self._with_ins:
             ego_state = self._ins_handler.get_ego_state(stamp=stamp)
-            ins_ego_pose_fields = self._get_ins_ego_pose_fields(stamp, ego_state=ego_state)
+            twist, acceleration, geocoordinate = self._get_ins_ego_pose_fields(
+                stamp, ego_state=ego_state
+            )
 
             ego_pose_token = self._ego_pose_table.insert_into_table(
                 translation=(
@@ -1246,7 +1237,9 @@ class _Rosbag2ToNonAnnotatedT4Converter:
                     ego_state.rotation.z,
                 ),
                 timestamp=rosbag2_utils.stamp_to_nusc_timestamp(ego_state.header.stamp),
-                **ins_ego_pose_fields,
+                twist=twist,
+                acceleration=acceleration,
+                geocoordinate=geocoordinate,
             )
         else:
             transform_stamped = self._bag_reader.get_transform_stamped(
@@ -1254,7 +1247,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
                 source_frame=self._ego_pose_source_frame,
                 stamp=stamp,
             )
-            ins_ego_pose_fields = self._get_ins_ego_pose_fields(stamp)
+            twist, acceleration, geocoordinate = self._get_ins_ego_pose_fields(stamp)
 
             ego_pose_token = self._ego_pose_table.insert_into_table(
                 translation=(
@@ -1269,7 +1262,9 @@ class _Rosbag2ToNonAnnotatedT4Converter:
                     transform_stamped.transform.rotation.z,
                 ),
                 timestamp=rosbag2_utils.stamp_to_nusc_timestamp(transform_stamped.header.stamp),
-                **ins_ego_pose_fields,
+                twist=twist,
+                acceleration=acceleration,
+                geocoordinate=geocoordinate,
             )
 
         return ego_pose_token
@@ -1277,10 +1272,16 @@ class _Rosbag2ToNonAnnotatedT4Converter:
     def _get_ins_ego_pose_fields(
         self,
         stamp: builtin_interfaces.msg.Time,
-        ego_state=None,
-    ) -> Dict[str, object]:
+        ego_state: Optional[EgoState] = None,
+    ) -> Tuple[
+        Optional[Tuple[float, ...]],
+        Optional[Tuple[float, ...]],
+        Optional[Tuple[float, float, float]],
+    ]:
         if self._ins_handler is None:
-            return {}
+            if self._with_ins:
+                raise RuntimeError("INS handler is not initialized while with_ins is enabled.")
+            return None, None, None
 
         try:
             if ego_state is None:
@@ -1288,14 +1289,23 @@ class _Rosbag2ToNonAnnotatedT4Converter:
             geocoordinate = self._ins_handler.lookup_nav_sat_fixes(stamp)
         except Exception as e:
             if self._with_ins:
-                raise
+                raise RuntimeError(
+                    f"Failed to get ego pose fields from INS at stamp {stamp}."
+                ) from e
             if not self._optional_ins_lookup_warning_logged:
                 logger.warning(f"Skipping optional INS ego_pose fields: {e}")
                 self._optional_ins_lookup_warning_logged = True
-            return {}
+            return None, None, None
+        geocoordinate_tuple = None
+        if geocoordinate is not None:
+            geocoordinate_tuple = (
+                geocoordinate.latitude,
+                geocoordinate.longitude,
+                geocoordinate.altitude,
+            )
 
-        return {
-            "twist": (
+        return (
+            (
                 ego_state.twist.linear.x,
                 ego_state.twist.linear.y,
                 ego_state.twist.linear.z,
@@ -1303,21 +1313,13 @@ class _Rosbag2ToNonAnnotatedT4Converter:
                 ego_state.twist.angular.y,
                 ego_state.twist.angular.x,
             ),
-            "acceleration": (
+            (
                 ego_state.accel.x,
                 ego_state.accel.y,
                 ego_state.accel.z,
             ),
-            "geocoordinate": (
-                (
-                    geocoordinate.latitude,
-                    geocoordinate.longitude,
-                    geocoordinate.altitude,
-                )
-                if geocoordinate is not None
-                else None
-            ),
-        }
+            geocoordinate_tuple,
+        )
 
     def _generate_vehicle_state(self, stamp: builtin_interfaces.msg.Time) -> str:
         nusc_timestamp = rosbag2_utils.stamp_to_nusc_timestamp(stamp)

--- a/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
@@ -246,13 +246,12 @@ class _Rosbag2ToNonAnnotatedT4Converter:
         # for Co-MLOps
         self._with_ins = params.with_ins
         self._with_vehicle_status = params.with_vehicle_status
+        self._optional_ins_lookup_warning_logged = False
 
         if self._with_ins:
-            from perception_dataset.ros2.oxts_msgs.ins_handler import INSHandler
-
-            self._ins_handler = INSHandler(params.input_bag_path)
+            self._ins_handler = self._make_ins_handler(params)
         else:
-            self._ins_handler = None
+            self._ins_handler = self._make_optional_ins_handler(params)
 
         if self._with_vehicle_status:
             from perception_dataset.ros2.vehicle_msgs.vehicle_status_handler import (
@@ -262,6 +261,39 @@ class _Rosbag2ToNonAnnotatedT4Converter:
             self._vehicle_status_handler = VehicleStatusHandler(params.input_bag_path)
         else:
             self._vehicle_status_handler = None
+
+    def _make_ins_handler(self, params: Rosbag2ConverterParams):
+        from perception_dataset.ros2.oxts_msgs.ins_handler import INSHandler
+
+        if params.ins_topic_mapping is None:
+            return INSHandler(params.input_bag_path)
+        return INSHandler(
+            params.input_bag_path,
+            topic_mapping=params.ins_topic_mapping,
+        )
+
+    def _make_optional_ins_handler(self, params: Rosbag2ConverterParams):
+        from perception_dataset.ros2.oxts_msgs.ins_handler import INSHandler
+
+        topic_mapping = INSHandler.get_topic_mapping(params.ins_topic_mapping)
+        missing_topics = [
+            topic
+            for topic in topic_mapping.values()
+            if self._bag_reader.get_topic_count(topic) == 0
+        ]
+        if missing_topics:
+            logger.info(
+                "Skipping optional INS ego_pose fields because topics are not found: "
+                f"{missing_topics}"
+            )
+            return None
+
+        try:
+            return self._make_ins_handler(params)
+        except Exception as e:
+            logger.warning(f"Skipping optional INS ego_pose fields: {e}")
+            self._optional_ins_lookup_warning_logged = True
+            return None
 
     def _calc_actual_num_load_frames(self):
         # calculate minimum number of available frames in the rosbag
@@ -1199,7 +1231,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
     def _generate_ego_pose(self, stamp: builtin_interfaces.msg.Time) -> str:
         if self._with_ins:
             ego_state = self._ins_handler.get_ego_state(stamp=stamp)
-            geocoordinate = self._ins_handler.lookup_nav_sat_fixes(stamp)
+            ins_ego_pose_fields = self._get_ins_ego_pose_fields(stamp, ego_state=ego_state)
 
             ego_pose_token = self._ego_pose_table.insert_into_table(
                 translation=(
@@ -1214,28 +1246,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
                     ego_state.rotation.z,
                 ),
                 timestamp=rosbag2_utils.stamp_to_nusc_timestamp(ego_state.header.stamp),
-                twist=(
-                    ego_state.twist.linear.x,
-                    ego_state.twist.linear.y,
-                    ego_state.twist.linear.z,
-                    ego_state.twist.angular.z,
-                    ego_state.twist.angular.y,
-                    ego_state.twist.angular.x,
-                ),
-                acceleration=(
-                    ego_state.accel.x,
-                    ego_state.accel.y,
-                    ego_state.accel.z,
-                ),
-                geocoordinate=(
-                    (
-                        geocoordinate.latitude,
-                        geocoordinate.longitude,
-                        geocoordinate.altitude,
-                    )
-                    if geocoordinate is not None
-                    else None
-                ),
+                **ins_ego_pose_fields,
             )
         else:
             transform_stamped = self._bag_reader.get_transform_stamped(
@@ -1243,6 +1254,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
                 source_frame=self._ego_pose_source_frame,
                 stamp=stamp,
             )
+            ins_ego_pose_fields = self._get_ins_ego_pose_fields(stamp)
 
             ego_pose_token = self._ego_pose_table.insert_into_table(
                 translation=(
@@ -1257,9 +1269,55 @@ class _Rosbag2ToNonAnnotatedT4Converter:
                     transform_stamped.transform.rotation.z,
                 ),
                 timestamp=rosbag2_utils.stamp_to_nusc_timestamp(transform_stamped.header.stamp),
+                **ins_ego_pose_fields,
             )
 
         return ego_pose_token
+
+    def _get_ins_ego_pose_fields(
+        self,
+        stamp: builtin_interfaces.msg.Time,
+        ego_state=None,
+    ) -> Dict[str, object]:
+        if self._ins_handler is None:
+            return {}
+
+        try:
+            if ego_state is None:
+                ego_state = self._ins_handler.get_ego_state(stamp=stamp)
+            geocoordinate = self._ins_handler.lookup_nav_sat_fixes(stamp)
+        except Exception as e:
+            if self._with_ins:
+                raise
+            if not self._optional_ins_lookup_warning_logged:
+                logger.warning(f"Skipping optional INS ego_pose fields: {e}")
+                self._optional_ins_lookup_warning_logged = True
+            return {}
+
+        return {
+            "twist": (
+                ego_state.twist.linear.x,
+                ego_state.twist.linear.y,
+                ego_state.twist.linear.z,
+                ego_state.twist.angular.z,
+                ego_state.twist.angular.y,
+                ego_state.twist.angular.x,
+            ),
+            "acceleration": (
+                ego_state.accel.x,
+                ego_state.accel.y,
+                ego_state.accel.z,
+            ),
+            "geocoordinate": (
+                (
+                    geocoordinate.latitude,
+                    geocoordinate.longitude,
+                    geocoordinate.altitude,
+                )
+                if geocoordinate is not None
+                else None
+            ),
+        }
 
     def _generate_vehicle_state(self, stamp: builtin_interfaces.msg.Time) -> str:
         nusc_timestamp = rosbag2_utils.stamp_to_nusc_timestamp(stamp)

--- a/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
@@ -53,6 +53,7 @@ from perception_dataset.constants import (
     SENSOR_MODALITY_ENUM,
     T4_FORMAT_DIRECTORY_NAME,
 )
+from perception_dataset.ros2.oxts_msgs.ins_handler import EgoState, INSHandler
 from perception_dataset.rosbag2.converter_params import (
     DataType,
     LidarSensor,
@@ -61,7 +62,6 @@ from perception_dataset.rosbag2.converter_params import (
 )
 from perception_dataset.rosbag2.rosbag2_reader import Rosbag2Reader
 from perception_dataset.t4_dataset.table_handler import TableHandler
-from perception_dataset.ros2.oxts_msgs.ins_handler import EgoState, INSHandler
 from perception_dataset.utils.logger import configure_logger
 import perception_dataset.utils.misc as misc_utils
 import perception_dataset.utils.rosbag2 as rosbag2_utils
@@ -250,7 +250,9 @@ class _Rosbag2ToNonAnnotatedT4Converter:
         self._optional_ins_lookup_warning_logged = False
 
         if self._with_ins:
-            self._ins_handler = INSHandler(params.input_bag_path, topic_mapping=params.ins_topic_mapping)
+            self._ins_handler = INSHandler(
+                params.input_bag_path, topic_mapping=params.ins_topic_mapping
+            )
         else:
             self._ins_handler = self._make_optional_ins_handler(params)
 


### PR DESCRIPTION
## Description

`with_ins` was previously a parameter only used for DRS which didn't have localization information. All other workflows ignored IMU and GNSS information so `twist`, `acceleration` and `geocoordinate` in `ego_pose.json` was always `null` in t4datasets. 

Now, even with `with_ins: False`, the converter will look to fill those fields using the topics set by `ins_topic_mapping` config parameters. If these are not set or topics are not found, fallback to previous `null` behavior. 

The difference with `with_ins: True` and `with_ins: False` are in the `translation` and `rotation` fields.  `with_ins: False` just uses the information in `/tf` while `with_ins: True` ignores `/tf` and sets these using INS information.

This should not affect existing Process Configs as these parameters are optional, but for `ins_topic_mapping:` will have to be set for each vehicle, though I think it is mainly as follows for current j6gen2, jpntaxigen2 and largebus vehicles, so maybe this is a good default:
```
ins_topic_mapping: # mappings for j6gen2 and jpntaxigen2
  imu: /sensing/imu/tamagawa/imu_raw
  nav_sat_fix: /sensing/gnss/septentrio/nav_sat_fix
  odometry: /localization/kinematic_state
```

## Related PRs

Seems like this PR tried to do similar thing #260, didn't notice.