### PR TITLE
fix(table_duplicate): allow EgoPose and VehicleState token re-use

### DIFF
--- a/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
+++ b/perception_dataset/rosbag2/rosbag2_to_non_annotated_t4_converter.py
@@ -1249,6 +1249,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
             )
 
             ego_pose_token = self._ego_pose_table.insert_into_table(
+                reuse_if_duplicate=True,
                 translation=(
                     ego_state.translation.x,
                     ego_state.translation.y,
@@ -1274,6 +1275,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
             twist, acceleration, geocoordinate = self._get_ins_ego_pose_fields(stamp)
 
             ego_pose_token = self._ego_pose_table.insert_into_table(
+                reuse_if_duplicate=True,
                 translation=(
                     transform_stamped.transform.translation.x,
                     transform_stamped.transform.translation.y,
@@ -1390,6 +1392,7 @@ class _Rosbag2ToNonAnnotatedT4Converter:
         )
 
         vehicle_state_token = self._vehicle_state_table.insert_into_table(
+            reuse_if_duplicate=True,
             timestamp=nusc_timestamp,
             accel_pedal=actuation_msg.status.accel_status,
             brake_pedal=actuation_msg.status.brake_status,

--- a/perception_dataset/t4_dataset/table_handler.py
+++ b/perception_dataset/t4_dataset/table_handler.py
@@ -133,7 +133,7 @@ class TableHandler(Generic[SchemaRecord]):
             for existing_token in self._content_hash_to_tokens[content_hash]:
                 existing_record = self._token_to_record[existing_token]
                 if self._is_duplicate_record(temp_record, existing_record):
-                    # Some tables (EgoPose, VehicleState) legitimately produce identical records 
+                    # Some tables (EgoPose, VehicleState) legitimately produce identical records
                     # when two frames have the same microsecond timestamp and state, so we re-use them.
                     if reuse_if_duplicate:
                         return existing_token

--- a/perception_dataset/t4_dataset/table_handler.py
+++ b/perception_dataset/t4_dataset/table_handler.py
@@ -122,6 +122,23 @@ class TableHandler(Generic[SchemaRecord]):
         return dict1 == dict2
 
     def insert_into_table(self, *, reuse_if_duplicate: bool = False, **kwargs) -> str:
+        """Insert a new record into the table and return its token.
+
+        Args:
+            reuse_if_duplicate (bool): If True and a record with identical content
+                already exists, return the existing token instead of raising.
+                Defaults to False (strict duplicate detection).
+            **kwargs: Field names and values of the record to insert. The token is
+                generated automatically.
+
+        Returns:
+            str: Token of the newly inserted record, or of the existing duplicate
+                record when ``reuse_if_duplicate=True``.
+
+        Raises:
+            ValueError: If a record with identical content already exists and
+                ``reuse_if_duplicate`` is False.
+        """
         # Create a temporary record to compare
         temp_record = self._to_record(**kwargs)
 

--- a/perception_dataset/t4_dataset/table_handler.py
+++ b/perception_dataset/t4_dataset/table_handler.py
@@ -121,7 +121,7 @@ class TableHandler(Generic[SchemaRecord]):
 
         return dict1 == dict2
 
-    def insert_into_table(self, **kwargs) -> str:
+    def insert_into_table(self, *, reuse_if_duplicate: bool = False, **kwargs) -> str:
         # Create a temporary record to compare
         temp_record = self._to_record(**kwargs)
 
@@ -133,6 +133,10 @@ class TableHandler(Generic[SchemaRecord]):
             for existing_token in self._content_hash_to_tokens[content_hash]:
                 existing_record = self._token_to_record[existing_token]
                 if self._is_duplicate_record(temp_record, existing_record):
+                    # Some tables (EgoPose, VehicleState) legitimately produce identical records 
+                    # when two frames have the same microsecond timestamp and state, so we re-use them.
+                    if reuse_if_duplicate:
+                        return existing_token
                     raise ValueError(
                         f"Duplicate record found in table {self._schema_type.__name__}. "
                         f"Existing token: {existing_token}"

--- a/tests/test_table_handler.py
+++ b/tests/test_table_handler.py
@@ -423,14 +423,14 @@ class TestTableHandlerReuseIfDuplicate(unittest.TestCase):
 
     @staticmethod
     def _ego_pose_kwargs(**overrides):
-        kwargs = dict(
-            translation=(1.0, 2.0, 3.0),
-            rotation=(0.0, 0.0, 0.0, 1.0),
-            timestamp=1_000_000,
-            twist=None,
-            acceleration=None,
-            geocoordinate=None,
-        )
+        kwargs = {
+            "translation": (1.0, 2.0, 3.0),
+            "rotation": (0.0, 0.0, 0.0, 1.0),
+            "timestamp": 1_000_000,
+            "twist": None,
+            "acceleration": None,
+            "geocoordinate": None,
+        }
         kwargs.update(overrides)
         return kwargs
 

--- a/tests/test_table_handler.py
+++ b/tests/test_table_handler.py
@@ -436,12 +436,8 @@ class TestTableHandlerReuseIfDuplicate(unittest.TestCase):
 
     def test_reuse_returns_existing_token(self):
         """Identical content with reuse_if_duplicate=True reuses the first token."""
-        token1 = self.handler.insert_into_table(
-            reuse_if_duplicate=True, **self._ego_pose_kwargs()
-        )
-        token2 = self.handler.insert_into_table(
-            reuse_if_duplicate=True, **self._ego_pose_kwargs()
-        )
+        token1 = self.handler.insert_into_table(reuse_if_duplicate=True, **self._ego_pose_kwargs())
+        token2 = self.handler.insert_into_table(reuse_if_duplicate=True, **self._ego_pose_kwargs())
 
         self.assertEqual(token1, token2)
         self.assertEqual(len(self.handler), 1)

--- a/tests/test_table_handler.py
+++ b/tests/test_table_handler.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch
 
 import attrs
-from t4_devkit.schema import Category, Instance, SampleAnnotation
+from t4_devkit.schema import Category, EgoPose, Instance, SampleAnnotation
 
 from perception_dataset.t4_dataset.table_handler import TableHandler
 
@@ -413,6 +413,102 @@ class TestTableHandler(unittest.TestCase):
                 num_lidar_pts=100,
                 num_radar_pts=0,
             )
+
+
+class TestTableHandlerReuseIfDuplicate(unittest.TestCase):
+    """Test the opt-in reuse_if_duplicate behavior (used by EgoPose / VehicleState)."""
+
+    def setUp(self):
+        self.handler = TableHandler(EgoPose)
+
+    @staticmethod
+    def _ego_pose_kwargs(**overrides):
+        kwargs = dict(
+            translation=(1.0, 2.0, 3.0),
+            rotation=(0.0, 0.0, 0.0, 1.0),
+            timestamp=1_000_000,
+            twist=None,
+            acceleration=None,
+            geocoordinate=None,
+        )
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_reuse_returns_existing_token(self):
+        """Identical content with reuse_if_duplicate=True reuses the first token."""
+        token1 = self.handler.insert_into_table(
+            reuse_if_duplicate=True, **self._ego_pose_kwargs()
+        )
+        token2 = self.handler.insert_into_table(
+            reuse_if_duplicate=True, **self._ego_pose_kwargs()
+        )
+
+        self.assertEqual(token1, token2)
+        self.assertEqual(len(self.handler), 1)
+
+    def test_default_still_raises_on_duplicate(self):
+        """The default (reuse_if_duplicate=False) keeps the strict duplicate-error invariant."""
+        self.handler.insert_into_table(**self._ego_pose_kwargs())
+
+        with self.assertRaises(ValueError) as context:
+            self.handler.insert_into_table(**self._ego_pose_kwargs())
+
+        self.assertIn("Duplicate record found", str(context.exception))
+        self.assertEqual(len(self.handler), 1)
+
+    def test_reuse_does_not_over_collapse_distinct_content(self):
+        """Records differing only by timestamp are distinct, even with reuse enabled."""
+        token1 = self.handler.insert_into_table(
+            reuse_if_duplicate=True, **self._ego_pose_kwargs(timestamp=1_000_000)
+        )
+        token2 = self.handler.insert_into_table(
+            reuse_if_duplicate=True, **self._ego_pose_kwargs(timestamp=1_000_001)
+        )
+
+        self.assertNotEqual(token1, token2)
+        self.assertEqual(len(self.handler), 2)
+
+    def test_reuse_path_does_not_corrupt_hash_index(self):
+        """A reuse hit must not mutate the hash index or break later strict inserts."""
+        token_a = self.handler.insert_into_table(
+            reuse_if_duplicate=True, **self._ego_pose_kwargs(timestamp=1_000_000)
+        )
+        # Reuse A (no new record added).
+        self.assertEqual(
+            self.handler.insert_into_table(
+                reuse_if_duplicate=True, **self._ego_pose_kwargs(timestamp=1_000_000)
+            ),
+            token_a,
+        )
+
+        # Distinct record B inserts under the default strict mode.
+        token_b = self.handler.insert_into_table(**self._ego_pose_kwargs(timestamp=2_000_000))
+        self.assertNotEqual(token_a, token_b)
+        self.assertEqual(len(self.handler), 2)
+
+        # An exact duplicate of B under strict mode still raises.
+        with self.assertRaises(ValueError):
+            self.handler.insert_into_table(**self._ego_pose_kwargs(timestamp=2_000_000))
+
+    def test_reuse_honors_equality_gate_under_hash_collision(self):
+        """With a forced hash collision, content-distinct records still insert as new tokens."""
+        with patch.object(self.handler, "_get_record_content_hash", return_value="same_hash"):
+            token1 = self.handler.insert_into_table(
+                reuse_if_duplicate=True, **self._ego_pose_kwargs(timestamp=1_000_000)
+            )
+            # Same hash but different content -> must NOT be reused.
+            token2 = self.handler.insert_into_table(
+                reuse_if_duplicate=True, **self._ego_pose_kwargs(timestamp=1_000_001)
+            )
+            self.assertNotEqual(token1, token2)
+            self.assertEqual(len(self.handler), 2)
+
+            # Same hash AND identical content -> reused.
+            token3 = self.handler.insert_into_table(
+                reuse_if_duplicate=True, **self._ego_pose_kwargs(timestamp=1_000_000)
+            )
+            self.assertEqual(token1, token3)
+            self.assertEqual(len(self.handler), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary 

`TableHandler.insert_into_table` rejects duplicates, raising ValueError. This is correct for most tables as a duplicate usually signals a real double-insertion bug, but it is often incorrect for EgoPose and VehicleState which can potentially have the same pose, especially after microsecond truncation of timestamps. This has cause occasional conversion time errors.

This PR fixes this by allowing token re-use for EgoPose and VehicleState records.

## Description

An EgoPose record's content is [translation, rotation, timestamp, twist, acceleration, geocoordinate], where timestamp is truncated to microseconds. Two sensor frames can legitimately produce byte-identical EgoPose content when they resolve to the same microsecond and the same pose. The known scenarios where this happens are:

* Same-microsecond images — two camera frames whose timestamps truncate to the same microsecond
* Stationary / interpolated pose — the /tf lookup (or INS) returns the same transform for nearby stamps
* Dummy/blank dropped-image pathway — dummy timestamps computed by float arithmetic in  perception_dataset/utils/misc.py land two frames in the same microsecond bucket while the pose is unchanged, which is likely when there is many (consecutive) dropped frames

VehicleState (_generate_vehicle_state, line 1392) hits the identical crash for the same reason (two identical actuation samples at the same microsecond).

As I do not want to allow/reuse _all_ duplicates I add `reuse_if_duplicate: bool = False` keyword in `perception_dataset/t4_dataset/table_handler.py` to be used only in ` _generate_ego_pose branches` (INS + /tf) and at `_generate_vehicle_state`

## Tests

Tested in Jazzy on two sequences: 

Scene 1 ([71f0af00](https://console.data-search.tier4.jp/oidc/auth/cb/?code=ory_ac_VjjYOtnni8Fnkd6_t2NrxG_JVtkirgaxwigNxdjmZds.VAkPBacEIkEmfq_nQLZT8bJV6lzj8eng6HuaymjmJj0&scope=openid+profile+email+offline_access&state=6f8fe765376a4adfb785ee2fdc09dc23)) : sample data: 3120,  ego_pose:  3117, reused: 3
Scene 2 ([4070c61b](https://console.data-search.tier4.jp/projects/x2_dev/t4datasets/4070c61b-408e-484d-a997-286a3417fd63?version=0&tab=report&executionCount=1)) :  sample data: 7092,  ego_pose: 7091, reused: 1

Confirmed no regression on current humble tests.
