### PR TITLE
chore(release_v1.0.34): bump version to v1.0.34

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "perception-dataset"
-version = "1.0.33"
+version = "1.0.34"
 description = "TIER IV Perception dataset has modules to convert dataset from rosbag to t4_dataset"
 authors = [
     { name = "Yusuke Muramatsu", email = "yusuke.muramatsu@tier4.jp" },


### PR DESCRIPTION
Release PR for v1.0.34 including:
* #307 bugfix: allowing EgoPose and VehicleState to re-use table entries
* #308 chore: documentation update