### PR TITLE
fix(ins_handler): remove tentative INS coordinate correction

### DIFF
--- a/perception_dataset/ros2/oxts_msgs/ins_handler.py
+++ b/perception_dataset/ros2/oxts_msgs/ins_handler.py
@@ -379,21 +379,6 @@ class INSHandler:
                 imu.linear_acceleration.z,
             ]
 
-            if True:
-                # TODO: tentative correction. If the INS coordinates are fixed, remove this correction.
-                r_current = Rotation.from_quat(current_rotation)
-                roll, pitch, yaw = r_current.as_euler("xyz")
-                yaw = yaw - np.pi / 2
-                roll = roll + np.pi
-                r_new = (
-                    Rotation.from_euler("z", yaw)
-                    * Rotation.from_euler("y", pitch)
-                    * Rotation.from_euler("x", roll)
-                )
-                current_rotation = r_new.as_quat()
-                current_twist.angular.z = -current_twist.angular.z
-                current_acceleration[1] = -current_acceleration[1]
-
             ego_state = EgoState(
                 header=odometry.header,
                 translation=Vector3(


### PR DESCRIPTION
## Description

`with_ins` / `ins_topic_mapping` control where each `ego_pose.json` field in the T4 dataset is sourced from:

| Field | `with_ins = true`<br>`ins_topic_mapping` set | `with_ins = false`<br>`ins_topic_mapping` set | `with_ins = false`<br>`ins_topic_mapping` not set |
| --- | --- | --- | --- |
| `translation` | INS `odometry` | `/tf` | `/tf` |
| `rotation` | INS `odometry` ⚠️ | `/tf` | `/tf` |
| `twist` | INS `odometry` ⚠️ | INS `odometry` ⚠️ | `Null` |
| `accel` | INS `imu` ⚠️ | INS `imu` ⚠️ | `Null` |
| `geocoordinate` | INS `nav_sat_fix` | INS `nav_sat_fix` | `Null` |

⚠️ = the *tentative correction* below is applied to this cell.

`INSHandler._localize_with_odometry` (`perception_dataset/ros2/oxts_msgs/ins_handler.py`) contains a hard-coded `if True:` *tentative correction* applied to every INS-sourced `EgoState`:

- **rotation**: decomposed to Euler `xyz`, then re-composed with `roll += π` and `yaw -= π/2`
- **twist** (`angular.z` only): sign flipped
- **accel** (`y` component only): sign flipped

The ⚠️ cells above are exactly the fields that carry this correction.

### Why remove it

This correction was a temporary workaround introduced to retroactively patch data that had been recorded with a misconfigured INS setup. That situation no longer applies, so the correction is no longer needed — and worse, applying it to correctly-recorded data corrupts the ego_pose. It should therefore be removed.

**This PR removes that block**, so those fields are written using the exact same values as in the input rosbag (odometry for `rotation` / `twist`, imu for `accel`), without any modification.

## Notes for users

- No config change is required for this PR.
- If you have implemented your own post-processing that cancels out this tentative correction, that step is no longer needed and should be removed.

## How to test

### test data

Any rosbag that contains the target vehicle's INS topics (odometry / imu / nav_sat_fix).

### test command

1. Prepare a `convert_rosbag2_to_non_annotated_t4` config with `ins_topic_mapping` pointing at the rosbag's INS topics, e.g.:

   ```yaml
   conversion:
     with_ins: true
     ins_topic_mapping:
       imu: /sensing/imu/tamagawa/imu_raw
       nav_sat_fix: /sensing/gnss/septentrio/nav_sat_fix
       odometry: /localization/kinematic_state
   ```

2. Run the conversion once with `with_ins: true` and once with `with_ins: false`:

   ```bash
   python -m perception_dataset.convert --config <your_config>.yaml
   ```

3. Diff `ego_pose.json` against a baseline generated before this PR and confirm the correction (`roll += π`, `yaw -= π/2`, `angular.z` & `accel.y` sign flips) is gone:

   - **`with_ins: true`**: the correction is gone from `rotation` / `twist` / `accel`.
   - **`with_ins: false`** (INS topics present): the correction is gone from `twist` / `accel` (`rotation` comes from `/tf` and is unaffected).